### PR TITLE
fix(gui): prevent points being moved outside axis bounds

### DIFF
--- a/src/gui/components/GraphComponent.h
+++ b/src/gui/components/GraphComponent.h
@@ -261,6 +261,11 @@ void GraphComponent<ValueType>::mouseDown(const juce::MouseEvent& event)
 template <typename ValueType>
 void GraphComponent<ValueType>::mouseDrag(const juce::MouseEvent& event)
 {
+    if (!getLocalBounds().contains(event.getPosition()))
+    {
+        return;
+    }
+
     if (pointEditState == PointEditingState::Move)
     {
         jassert(movingPointIndex != -1 && movingPointIndex < points.size());

--- a/src/gui/components/GraphComponent.h
+++ b/src/gui/components/GraphComponent.h
@@ -7,6 +7,7 @@
 
 #include "../../Interpolator.h"
 #include "../utility/PointComparator.h"
+#include "../utility/clip.h"
 #include <JuceHeader.h>
 #include <memory>
 
@@ -35,6 +36,8 @@ public:
     void setEditable(bool shouldBeEditable = true);
     void setInterpolationMethod(const juce::Identifier& identifier);
 
+    ValueType getMinX() const;
+    ValueType getMinY() const;
     ValueType getMaxX() const;
     ValueType getMaxY() const;
     bool isEditable() const;
@@ -106,6 +109,11 @@ GraphComponent<ValueType>::GraphComponent()
     setInterpolationMethod(SplineInterpolator<ValueType>::identifier);
 
     addKeyListener(this);
+
+    DBG(getMinX());
+    DBG(getMinY());
+    DBG(getMaxX());
+    DBG(getMinY());
 }
 
 /**
@@ -130,8 +138,26 @@ void GraphComponent<ValueType>::setRangeX(ValueType min, ValueType max)
 template <typename ValueType>
 void GraphComponent<ValueType>::setRangeY(ValueType min, ValueType max)
 {
-    valueBounds.setY(max);
+    valueBounds.setY(min);
     valueBounds.setHeight(max - min);
+}
+
+/**
+ * @brief Returns the minimum value of the x-axis
+ */
+template <typename ValueType>
+ValueType GraphComponent<ValueType>::getMinX() const
+{
+    return valueBounds.getX();
+}
+
+/**
+ * @brief Returns the minimum value of the y-axis
+ */
+template <typename ValueType>
+ValueType GraphComponent<ValueType>::getMinY() const
+{
+    return valueBounds.getY();
 }
 
 /**
@@ -140,7 +166,7 @@ void GraphComponent<ValueType>::setRangeY(ValueType min, ValueType max)
 template <typename ValueType>
 ValueType GraphComponent<ValueType>::getMaxX() const
 {
-    return valueBounds.getWidth();
+    return valueBounds.getWidth() - valueBounds.getX();
 }
 
 /**
@@ -149,7 +175,7 @@ ValueType GraphComponent<ValueType>::getMaxX() const
 template <typename ValueType>
 ValueType GraphComponent<ValueType>::getMaxY() const
 {
-    return valueBounds.getHeight();
+    return valueBounds.getHeight() - valueBounds.getY();
 }
 
 /**
@@ -261,10 +287,6 @@ void GraphComponent<ValueType>::mouseDown(const juce::MouseEvent& event)
 template <typename ValueType>
 void GraphComponent<ValueType>::mouseDrag(const juce::MouseEvent& event)
 {
-    if (!getLocalBounds().contains(event.getPosition()))
-    {
-        return;
-    }
 
     if (pointEditState == PointEditingState::Move)
     {
@@ -536,6 +558,9 @@ juce::Point<ValueType> GraphComponent<ValueType>::transformPointToGraph(const ju
 
     auto x = static_cast<ValueType>(point.getX() * xScale);
     auto y = getMaxY() - static_cast<ValueType>(point.getY() * yScale);
+
+    x = utility::clip(x, getMinX(), getMaxX());
+    y = utility::clip(y, getMinY(), getMaxY());
 
     return {x, y};
 }


### PR DESCRIPTION
## Description
- Prevents points from being dragged outside axis bounds.
- When mouse position is outside the bounds of one axis but not the other, points can still be moved along the other axis.

Closes #45 

## Checklist
- [x] Code linted with `trunk check`
- [x] Code formatted with `trunk fmt`
- [x] Changes do not generate any new compiler warnings 
- [x] Commit messages follow the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
