### PR TITLE
build: disable missing prototype warnings in external spline library

### DIFF
--- a/src/Interpolator.h
+++ b/src/Interpolator.h
@@ -8,11 +8,12 @@
 
 #include <JuceHeader.h>
 
-#pragma GCC diagnostic push // disable warnings from external lib
+#pragma GCC diagnostic push // disable warnings from external spline library
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Wextra-semi"
+#pragma GCC diagnostic ignored "-Wmissing-prototypes"
 #pragma GCC diagnostic ignored "-Wc++98-compat-extra-semi"
-#define NDEBUG // prevent assert() in lib
+#define NDEBUG // prevent assert()
 #include <spline.h>
 #undef NDEBUG
 #pragma GCC diagnostic pop


### PR DESCRIPTION
## Description
- Disables `-Wmissing-prototypes` from external spline library.

Closes #65 

## Checklist
- [x] Code linted with `trunk check`
- [x] Code formatted with `trunk fmt`
- [x] Changes do not generate any new compiler warnings 
- [x] Commit messages follow the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
