### PR TITLE
feat(gui): create menu bar outline

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -14,7 +14,10 @@
 void Application::initialise(const juce::String& /*commandLine*/)
 {
     configValueTree = std::make_shared<ConfigurationValueTree>();
-    commandManager = std::make_unique<CommandManager>();
+
+    commandManager = std::make_shared<CommandManager>();
+    commandManager->registerAllCommandsForTarget(this);
+
     mainWindow = std::make_unique<gui::MainWindow>(getApplicationName(), configValueTree, commandManager);
 }
 

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -14,7 +14,8 @@
 void Application::initialise(const juce::String& /*commandLine*/)
 {
     configValueTree = std::make_shared<ConfigurationValueTree>();
-    mainWindow = std::make_unique<gui::MainWindow>(getApplicationName(), configValueTree);
+    commandManager = std::make_unique<CommandManager>();
+    mainWindow = std::make_unique<gui::MainWindow>(getApplicationName(), configValueTree, commandManager);
 }
 
 /**

--- a/src/Application.h
+++ b/src/Application.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "CommandManager.h"
 #include "ConfigurationValueTree.h"
 #include "gui/windows/MainWindow.h"
 #include <JuceHeader.h>
@@ -33,4 +34,5 @@ private:
 
     std::unique_ptr<gui::MainWindow> mainWindow;
     std::shared_ptr<ConfigurationValueTree> configValueTree;
+    std::shared_ptr<CommandManager> commandManager;
 };

--- a/src/CommandManager.h
+++ b/src/CommandManager.h
@@ -1,0 +1,38 @@
+/******************************************************************************
+ * @file    CommandManager.h
+ * @author  Tim Brewis (@t-bre, tab1g19@soton.ac.uk)
+ * @brief   Application command manager
+ *****************************************************************************/
+
+#pragma once
+
+#include <JuceHeader.h>
+
+/**
+ * @brief Application command manager
+ */
+class CommandManager : public juce::ApplicationCommandManager
+{
+public:
+
+    CommandManager() = default;
+    ~CommandManager() = default;
+
+    enum CommandIDs
+    {
+        // menu bar
+        ShowAboutWindow = 0x100020,
+        ShowPreferencesWindow = 0x100021,
+
+        // windows
+        CloseWindow = 0x100030,
+        MinimiseWindow = 0x100031,
+        ToggleFullScreen = 0x100032,
+    };
+
+    struct CommandCategories
+    {
+        inline static const char* General = "General";
+        inline static const char* GUI = "GUI";
+    };
+};

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -12,5 +12,6 @@ target_sources(${TARGET_NAME}
     PRIVATE 
         components/MainComponent.cpp 
         components/TorqueMapComponent.cpp
+        menubar/MenuBar.cpp
         windows/MainWindow.cpp
 )

--- a/src/gui/components/GraphComponent.h
+++ b/src/gui/components/GraphComponent.h
@@ -5,6 +5,8 @@
  * @brief  Component for drawing a graph
  *****************************************************************************/
 
+#pragma once
+
 #include "../../Interpolator.h"
 #include "../utility/PointComparator.h"
 #include "../utility/clip.h"

--- a/src/gui/components/MainComponent.h
+++ b/src/gui/components/MainComponent.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include "../../Application.h"
 #include "TorqueMapComponent.h"
 #include <JuceHeader.h>
 

--- a/src/gui/components/TorqueMapComponent.h
+++ b/src/gui/components/TorqueMapComponent.h
@@ -4,6 +4,8 @@
  * @brief  Component for drawing the torque map
  *****************************************************************************/
 
+#pragma once
+
 #include "../../ConfigurationValueTree.h"
 #include "GraphComponent.h"
 #include <JuceHeader.h>

--- a/src/gui/menubar/MenuBar.cpp
+++ b/src/gui/menubar/MenuBar.cpp
@@ -12,8 +12,7 @@ namespace gui
 /**
  * @brief Constructor
  */
-MenuBar::MenuBar(std::shared_ptr<CommandManager> sharedCommandManager)
-    : commandManager(sharedCommandManager)
+MenuBar::MenuBar(std::shared_ptr<CommandManager> sharedCommandManager) : commandManager(sharedCommandManager)
 {
     jassert(commandManager);
     commandManager->registerAllCommandsForTarget(this);

--- a/src/gui/menubar/MenuBar.cpp
+++ b/src/gui/menubar/MenuBar.cpp
@@ -1,0 +1,224 @@
+/******************************************************************************
+ * @file    MenuBar.cpp
+ * @author  Tim Brewis (@t-bre, tab1g19@soton.ac.uk)
+ * @brief   Menu bar
+ *****************************************************************************/
+
+#include "MenuBar.h"
+
+namespace gui
+{
+
+/**
+ * @brief Constructor
+ */
+MenuBar::MenuBar(std::shared_ptr<CommandManager> sharedCommandManager)
+    : commandManager(sharedCommandManager)
+{
+    jassert(commandManager);
+    commandManager->registerAllCommandsForTarget(this);
+    setApplicationCommandManagerToWatch(commandManager.get());
+
+    createMainMenu();
+
+#if JUCE_MAC
+    setupAppleMenu();
+#endif
+}
+
+/**
+ * @brief Destructor
+ */
+MenuBar::~MenuBar()
+{
+#if JUCE_MAC
+    setMacMainMenu(nullptr);
+#endif
+}
+
+/**
+ * @brief Creates the main menu
+ */
+void MenuBar::createMainMenu()
+{
+    mainMenu.addCommandItem(commandManager.get(), CommandManager::CommandIDs::ShowAboutWindow);
+}
+
+#if JUCE_MAC
+/**
+ * @brief Set ups the 'Apple' menu (macOS only)
+ */
+void MenuBar::setupAppleMenu()
+{
+    juce::PopupMenu::MenuItemIterator iter(mainMenu, false);
+
+    while (iter.next())
+    {
+        iter.getItem().setEnabled(true);
+    }
+
+    setMacMainMenu(this, &mainMenu);
+}
+#endif
+
+/**
+ * @brief Creates the 'Window' menu
+ */
+juce::PopupMenu MenuBar::createWindowMenu()
+{
+    juce::PopupMenu menu;
+
+    std::initializer_list<CommandManager::CommandIDs> commands = {
+        CommandManager::CloseWindow,
+        CommandManager::MinimiseWindow,
+    };
+
+    for (const auto& cmd : commands)
+    {
+        menu.addCommandItem(commandManager.get(), cmd);
+    }
+
+    return menu;
+}
+
+/**
+ * @brief Creates the 'View' menu
+ */
+juce::PopupMenu MenuBar::createViewMenu()
+{
+    juce::PopupMenu menu;
+
+    std::initializer_list<CommandManager::CommandIDs> commands = {
+        CommandManager::ToggleFullScreen,
+    };
+
+    for (const auto& cmd : commands)
+    {
+        menu.addCommandItem(commandManager.get(), cmd);
+    }
+
+    return menu;
+}
+
+/**
+ * @brief Implements juce::MenuBarModel::getMenuBarNames()
+ */
+juce::StringArray MenuBar::getMenuBarNames()
+{
+    juce::StringArray names;
+
+    for (const auto& [key, value] : menuNameMap)
+    {
+        names.add(value);
+    }
+
+    return names;
+}
+
+/**
+ * Implements juce::MenuBarModel::getMenuForIndex()
+ */
+juce::PopupMenu MenuBar::getMenuForIndex(int topLevelMenuIndex, const juce::String& menuName)
+{
+    (void) menuName;
+
+    switch (topLevelMenuIndex)
+    {
+    case MenuIndex::Window:
+        return createWindowMenu();
+
+    case MenuIndex::View:
+        return createViewMenu();
+
+    default:
+        return juce::PopupMenu();
+    }
+}
+
+/**
+ * Implements juce::MenuBarModel::menuItemSelected()
+ */
+// NOLINTBEGIN(bugprone-easily-swappable-parameters)
+void MenuBar::menuItemSelected(int /*menuItemID*/, int /*topLevelMenuIndex*/)
+{
+}
+// NOLINTEND(bugprone-easily-swappable-parameters)
+
+/**
+ * Implements juce::MenuBarModel::menuBarActivated()
+ */
+void MenuBar::menuBarActivated(bool /*isActive*/)
+{
+}
+
+/**
+ * Implements juce::ApplicationCommandTarget::getAllCommands()
+ */
+void MenuBar::getAllCommands(juce::Array<juce::CommandID>& commands)
+{
+    std::initializer_list<juce::CommandID> targetCommands = {
+        CommandManager::CommandIDs::ShowAboutWindow,
+    };
+
+    commands.addArray(targetCommands);
+}
+
+/**
+ * Implements juce::ApplicationCommandTarget::getCommandInfo()
+ */
+void MenuBar::getCommandInfo(juce::CommandID commandID, juce::ApplicationCommandInfo& result)
+{
+    switch (commandID)
+    {
+    case CommandManager::ShowAboutWindow:
+    {
+        result.setInfo(juce::String("About ") + ProjectInfo::projectName,
+                       "Shows about window",
+                       CommandManager::CommandCategories::GUI,
+                       0);
+        break;
+    }
+
+    default:
+        break;
+    }
+}
+
+/**
+ * Implements juce::ApplicationCommandTarget::perform()
+ */
+bool MenuBar::perform(const InvocationInfo& info)
+{
+    switch (info.commandID)
+    {
+    case CommandManager::ShowAboutWindow:
+    {
+        // TODO: implement
+        jassertfalse;
+        break;
+    }
+
+    default:
+        return false;
+    }
+
+    return true;
+}
+
+/**
+ * juce::ApplicationCommandTarget::getNextCommandTarget()
+ */
+juce::ApplicationCommandTarget* MenuBar::getNextCommandTarget()
+{
+    return nullptr;
+}
+
+/**
+ * @brief Map between menu indexes and identifying strings
+ */
+const std::map<MenuBar::MenuIndex, juce::String> MenuBar::menuNameMap = {
+    {MenuBar::MenuIndex::View, "View"},
+    {MenuBar::MenuIndex::Window, "Window"},
+};
+
+} // namespace gui

--- a/src/gui/menubar/MenuBar.h
+++ b/src/gui/menubar/MenuBar.h
@@ -1,0 +1,59 @@
+/******************************************************************************
+ * @file    MenuBar.h
+ * @author  Tim Brewis (@t-bre, tab1g19@soton.ac.uk)
+ * @brief   Menu bar
+ *****************************************************************************/
+
+#pragma once
+
+#include "../../CommandManager.h"
+#include <JuceHeader.h>
+#include <map>
+#include <memory>
+
+namespace gui
+{
+
+/**
+ * @brief Menu bar
+ */
+class MenuBar : public juce::MenuBarModel, public juce::ApplicationCommandTarget
+{
+public:
+
+    MenuBar(std::shared_ptr<CommandManager> sharedCommandManager);
+    ~MenuBar() override;
+
+    juce::StringArray getMenuBarNames() override;
+    juce::PopupMenu getMenuForIndex(int topLevelMenuIndex, const juce::String& menuName) override;
+    void menuItemSelected(int menuItemID, int topLevelMenuIndex) override;
+    void menuBarActivated(bool isActive) override;
+
+    void getAllCommands(juce::Array<juce::CommandID>& commands) override;
+    juce::ApplicationCommandTarget* getNextCommandTarget() override;
+    void getCommandInfo(juce::CommandID commandID, juce::ApplicationCommandInfo& result) override;
+    bool perform(const InvocationInfo& info) override;
+
+private:
+
+    void createMainMenu();
+    juce::PopupMenu createWindowMenu();
+    juce::PopupMenu createViewMenu();
+
+#if JUCE_MAC
+    void setupAppleMenu();
+#endif
+
+    juce::PopupMenu mainMenu;
+    std::shared_ptr<CommandManager> commandManager;
+
+    typedef enum
+    {
+        View = 0,
+        Window = 1,
+    } MenuIndex;
+
+    static const std::map<MenuIndex, juce::String> menuNameMap;
+};
+
+} // namespace gui

--- a/src/gui/windows/MainWindow.cpp
+++ b/src/gui/windows/MainWindow.cpp
@@ -23,7 +23,8 @@ MainWindow::MainWindow(const juce::String& name,
     : juce::DocumentWindow(
         name,
         juce::Desktop::getInstance().getDefaultLookAndFeel().findColour(juce::ResizableWindow::backgroundColourId),
-        DocumentWindow::allButtons)
+        DocumentWindow::allButtons),
+      menuBar(commandManager)
 {
     setUsingNativeTitleBar(true);
     setResizeLimits(minWidth, minHeight, INT_MAX, INT_MAX);

--- a/src/gui/windows/MainWindow.cpp
+++ b/src/gui/windows/MainWindow.cpp
@@ -17,7 +17,9 @@ namespace gui
  *
  * @param[in]   name    Window name
  */
-MainWindow::MainWindow(const juce::String& name, std::shared_ptr<ConfigurationValueTree> sharedConfigValueTree)
+MainWindow::MainWindow(const juce::String& name,
+                       std::shared_ptr<ConfigurationValueTree> sharedConfigValueTree,
+                       std::shared_ptr<CommandManager> commandManager)
     : juce::DocumentWindow(
         name,
         juce::Desktop::getInstance().getDefaultLookAndFeel().findColour(juce::ResizableWindow::backgroundColourId),

--- a/src/gui/windows/MainWindow.cpp
+++ b/src/gui/windows/MainWindow.cpp
@@ -32,7 +32,11 @@ MainWindow::MainWindow(const juce::String& name,
     setVisible(true);
     centreWithSize(getWidth(), getHeight());
 
+    jassert(sharedConfigValueTree);
     setContentOwned(new MainComponent(sharedConfigValueTree), true);
+
+    jassert(commandManager);
+    commandManager->registerAllCommandsForTarget(this);
 }
 
 /**

--- a/src/gui/windows/MainWindow.cpp
+++ b/src/gui/windows/MainWindow.cpp
@@ -43,4 +43,104 @@ void MainWindow::closeButtonPressed()
     JUCEApplication::getInstance()->systemRequestedQuit();
 }
 
+/**
+ * @brief Implements juce::ApplicationCommandTarget::getAllCommands()
+ */
+void MainWindow::getAllCommands(juce::Array<juce::CommandID>& commands)
+{
+    std::initializer_list<juce::CommandID> targetCommands = {
+        CommandManager::CloseWindow,
+        CommandManager::MinimiseWindow,
+        CommandManager::ToggleFullScreen,
+    };
+
+    commands.addArray(targetCommands);
+}
+
+/**
+ * @brief Implements juce::ApplicationCommandTarget::getCommandInfo()
+ */
+void MainWindow::getCommandInfo(juce::CommandID commandID,
+                                juce::ApplicationCommandInfo& result)
+{
+    switch (commandID)
+    {
+        case CommandManager::CloseWindow:
+        {
+            result.setInfo("Close",
+                           "Closes the window",
+                           CommandManager::CommandCategories::GUI,
+                           0);
+            result.defaultKeypresses.add(
+                juce::KeyPress('w', juce::ModifierKeys::commandModifier, 0));
+            break;
+        }
+
+        case CommandManager::MinimiseWindow:
+        {
+            result.setInfo("Minimise",
+                           "Minimises the window",
+                           CommandManager::CommandCategories::GUI,
+                           0);
+            result.defaultKeypresses.add(
+                juce::KeyPress('m', juce::ModifierKeys::commandModifier, 0));
+            break;
+        }
+
+        case CommandManager::ToggleFullScreen:
+        {
+            const juce::String shortName =
+                !isFullScreen() ? "Enter Full Screen" : "Exit Full Screen";
+            const juce::String longName =
+                !isFullScreen() ? "Enters full screen" : "Exits full screen";
+
+            result.setInfo(
+                shortName, longName, CommandManager::CommandCategories::GUI, 0);
+            result.defaultKeypresses.add(
+                juce::KeyPress('f',
+                               juce::ModifierKeys::commandModifier |
+                                   juce::ModifierKeys::ctrlModifier,
+                               0));
+            break;
+        }
+
+        default:
+            break;
+    }
+}
+
+/**
+ * @brief Implements juce::ApplicationCommandTarget::perform()
+ */
+bool MainWindow::perform(const InvocationInfo& info)
+{
+    switch (info.commandID)
+    {
+        case CommandManager::CloseWindow:
+            closeButtonPressed();
+            break;
+
+        case CommandManager::MinimiseWindow:
+            minimiseButtonPressed();
+            break;
+
+        case CommandManager::ToggleFullScreen:
+            setFullScreen(!isFullScreen());
+            break;
+
+        default:
+            return false;
+    }
+
+    return true;
+}
+
+/**
+ * @brief Implements juce::ApplicationCommandTarget::getNextCommandTarget()
+ */
+juce::ApplicationCommandTarget* MainWindow::getNextCommandTarget()
+{
+    return static_cast<juce::ApplicationCommandTarget*>(&menuBar);
+}
+
 } // namespace gui

--- a/src/gui/windows/MainWindow.h
+++ b/src/gui/windows/MainWindow.h
@@ -8,6 +8,7 @@
 
 #include "../../CommandManager.h"
 #include "../../ConfigurationValueTree.h"
+#include "../menubar/MenuBar.h"
 #include <JuceHeader.h>
 #include <memory>
 
@@ -28,6 +29,8 @@ public:
     void closeButtonPressed() override;
 
 private:
+
+    MenuBar menuBar;
 
     static const int minWidth = 500;
     static const int minHeight = 350;

--- a/src/gui/windows/MainWindow.h
+++ b/src/gui/windows/MainWindow.h
@@ -18,7 +18,7 @@ namespace gui
 /**
  * @brief Main GUI window
  */
-class MainWindow : public juce::DocumentWindow
+class MainWindow : public juce::DocumentWindow, juce::ApplicationCommandTarget
 {
 public:
 
@@ -27,6 +27,13 @@ public:
                std::shared_ptr<CommandManager> commandManager);
 
     void closeButtonPressed() override;
+
+    // command handling
+    void getAllCommands(juce::Array<juce::CommandID>& commands) override;
+    void getCommandInfo(juce::CommandID commandID,
+                        juce::ApplicationCommandInfo& result) override;
+    bool perform(const InvocationInfo& info) override;
+    juce::ApplicationCommandTarget* getNextCommandTarget() override;
 
 private:
 

--- a/src/gui/windows/MainWindow.h
+++ b/src/gui/windows/MainWindow.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "../../CommandManager.h"
 #include "../../ConfigurationValueTree.h"
 #include <JuceHeader.h>
 #include <memory>
@@ -20,7 +21,9 @@ class MainWindow : public juce::DocumentWindow
 {
 public:
 
-    MainWindow(const juce::String& name, std::shared_ptr<ConfigurationValueTree> sharedConfigValueTree);
+    MainWindow(const juce::String& name,
+               std::shared_ptr<ConfigurationValueTree> sharedConfigValueTree,
+               std::shared_ptr<CommandManager> commandManager);
 
     void closeButtonPressed() override;
 

--- a/src/gui/windows/MainWindow.h
+++ b/src/gui/windows/MainWindow.h
@@ -8,6 +8,7 @@
 
 #include "../../CommandManager.h"
 #include "../../ConfigurationValueTree.h"
+#include "../components/MainComponent.h"
 #include "../menubar/MenuBar.h"
 #include <JuceHeader.h>
 #include <memory>
@@ -24,20 +25,22 @@ public:
 
     MainWindow(const juce::String& name,
                std::shared_ptr<ConfigurationValueTree> sharedConfigValueTree,
-               std::shared_ptr<CommandManager> commandManager);
+               std::shared_ptr<CommandManager> sharedCommandManager);
+    ~MainWindow() override;
 
     void closeButtonPressed() override;
 
     // command handling
     void getAllCommands(juce::Array<juce::CommandID>& commands) override;
-    void getCommandInfo(juce::CommandID commandID,
-                        juce::ApplicationCommandInfo& result) override;
+    void getCommandInfo(juce::CommandID commandID, juce::ApplicationCommandInfo& result) override;
     bool perform(const InvocationInfo& info) override;
     juce::ApplicationCommandTarget* getNextCommandTarget() override;
 
 private:
 
     MenuBar menuBar;
+    MainComponent mainComponent;
+    std::shared_ptr<CommandManager> commandManager;
 
     static const int minWidth = 500;
     static const int minHeight = 350;


### PR DESCRIPTION
## Description
- Creates the boilerplate for the menu bar including an application command manager.
- Fixes some build issues (missing `#pragma once` and a circular dependency). 

Closes #58 

## Checklist
- [x] Code linted with `trunk check`
- [x] Code formatted with `trunk fmt`
- [x] Changes do not generate any new compiler warnings 
- [x] Commit messages follow the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
