### PR TITLE
feat(gui): create 'About' window

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,23 @@ juce_add_binary_data(${TARGET_NAME}Data
         res/Delete.png
 )
 
+# get the commit hash
+execute_process(
+    COMMAND git rev-parse --abbrev-ref HEAD
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE GIT_BRANCH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+execute_process(
+    COMMAND git rev-parse HEAD
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE GIT_COMMIT_HASH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+
+
 # compilation
 target_compile_definitions(${TARGET_NAME}
     PRIVATE
@@ -60,6 +77,7 @@ target_compile_definitions(${TARGET_NAME}
         JUCE_USE_CURL=0
         JUCE_APPLICATION_NAME_STRING="$<TARGET_PROPERTY:${PROJECT_NAME},JUCE_PRODUCT_NAME>"
         JUCE_APPLICATION_VERSION_STRING="$<TARGET_PROPERTY:${PROJECT_NAME},JUCE_VERSION>"
+        -DGIT_COMMIT_HASH=\"${GIT_COMMIT_HASH}\"
 )
 
 # linking

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -74,12 +74,12 @@ bool Application::moreThanOneInstanceAllowed()
 
 /**
  * @brief   Implements juce::ApplicationCommandTarget::getNextCommandTarget()
- * 
+ *
  * @details This ensures that the main window is found as a target by the CommandManager when the app launches. Without
  *          this, if the user does not interact with a component inside the main window, menu bar items will be greyed
  *          out (though keyboard shortcuts will still work).
  */
 juce::ApplicationCommandTarget* Application::getNextCommandTarget()
-{   
+{
     return mainWindow.get();
 }

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -71,3 +71,15 @@ bool Application::moreThanOneInstanceAllowed()
 {
     return false;
 }
+
+/**
+ * @brief   Implements juce::ApplicationCommandTarget::getNextCommandTarget()
+ * 
+ * @details This ensures that the main window is found as a target by the CommandManager when the app launches. Without
+ *          this, if the user does not interact with a component inside the main window, menu bar items will be greyed
+ *          out (though keyboard shortcuts will still work).
+ */
+juce::ApplicationCommandTarget* Application::getNextCommandTarget()
+{   
+    return mainWindow.get();
+}

--- a/src/Application.h
+++ b/src/Application.h
@@ -30,6 +30,8 @@ public:
     const juce::String getApplicationVersion() override;
     bool moreThanOneInstanceAllowed() override;
 
+    juce::ApplicationCommandTarget* getNextCommandTarget() override;
+
 private:
 
     std::unique_ptr<gui::MainWindow> mainWindow;

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -13,5 +13,6 @@ target_sources(${TARGET_NAME}
         components/MainComponent.cpp 
         components/TorqueMapComponent.cpp
         menubar/MenuBar.cpp
+        windows/AboutWindow.cpp
         windows/MainWindow.cpp
 )

--- a/src/gui/menubar/MenuBar.cpp
+++ b/src/gui/menubar/MenuBar.cpp
@@ -192,8 +192,14 @@ bool MenuBar::perform(const InvocationInfo& info)
     {
     case CommandManager::ShowAboutWindow:
     {
-        // TODO: implement
-        jassertfalse;
+        if (!aboutWindow)
+        {
+            aboutWindow = std::make_unique<AboutWindow>(commandManager);
+            
+            aboutWindow->onCloseButtonPressed = [this](){
+                aboutWindow.reset();
+            };
+        }
         break;
     }
 

--- a/src/gui/menubar/MenuBar.cpp
+++ b/src/gui/menubar/MenuBar.cpp
@@ -195,10 +195,8 @@ bool MenuBar::perform(const InvocationInfo& info)
         if (!aboutWindow)
         {
             aboutWindow = std::make_unique<AboutWindow>(commandManager);
-            
-            aboutWindow->onCloseButtonPressed = [this](){
-                aboutWindow.reset();
-            };
+
+            aboutWindow->onCloseButtonPressed = [this]() { aboutWindow.reset(); };
         }
         break;
     }

--- a/src/gui/menubar/MenuBar.h
+++ b/src/gui/menubar/MenuBar.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "../../CommandManager.h"
+#include "../windows/AboutWindow.h"
 #include <JuceHeader.h>
 #include <map>
 #include <memory>
@@ -46,6 +47,7 @@ private:
 
     juce::PopupMenu mainMenu;
     std::shared_ptr<CommandManager> commandManager;
+    std::unique_ptr<AboutWindow> aboutWindow;
 
     typedef enum
     {

--- a/src/gui/windows/AboutWindow.cpp
+++ b/src/gui/windows/AboutWindow.cpp
@@ -61,24 +61,19 @@ void AboutWindow::getAllCommands(juce::Array<juce::CommandID>& commands)
 /**
  * @brief Implements juce::ApplicationCommandTarget::getCommandInfo()
  */
-void AboutWindow::getCommandInfo(juce::CommandID commandID,
-                                juce::ApplicationCommandInfo& result)
+void AboutWindow::getCommandInfo(juce::CommandID commandID, juce::ApplicationCommandInfo& result)
 {
     switch (commandID)
     {
-        case CommandManager::CloseWindow:
-        {
-            result.setInfo(juce::String("Close"),
-                           "Closes the window",
-                           CommandManager::CommandCategories::GUI,
-                           0);
-            result.defaultKeypresses.add(
-                juce::KeyPress('w', juce::ModifierKeys::commandModifier, 0));
-            break;
-        }
+    case CommandManager::CloseWindow:
+    {
+        result.setInfo(juce::String("Close"), "Closes the window", CommandManager::CommandCategories::GUI, 0);
+        result.defaultKeypresses.add(juce::KeyPress('w', juce::ModifierKeys::commandModifier, 0));
+        break;
+    }
 
-        default:
-            break;
+    default:
+        break;
     }
 }
 
@@ -89,21 +84,21 @@ bool AboutWindow::perform(const InvocationInfo& info)
 {
     switch (info.commandID)
     {
-        case CommandManager::CloseWindow:
-        {
-            closeButtonPressed();
-            break;
-        }
+    case CommandManager::CloseWindow:
+    {
+        closeButtonPressed();
+        break;
+    }
 
-        default:
-            return false;
+    default:
+        return false;
     }
 
     return true;
 }
 
 /**
- * @brief Implements juce::ApplicationCommandTarget::getNextCommandTarget() 
+ * @brief Implements juce::ApplicationCommandTarget::getNextCommandTarget()
  */
 juce::ApplicationCommandTarget* AboutWindow::getNextCommandTarget()
 {
@@ -117,8 +112,8 @@ AboutWindow::AboutComponent::AboutComponent()
 {
     setupLabels();
 
-    appIconImage.setImage(juce::ImageCache::getFromMemory(
-        BinaryData::AppIcon_1024_png, BinaryData::AppIcon_1024_pngSize));
+    appIconImage.setImage(
+        juce::ImageCache::getFromMemory(BinaryData::AppIcon_1024_png, BinaryData::AppIcon_1024_pngSize));
 
     addAndMakeVisible(appIconImage);
 }
@@ -128,33 +123,25 @@ AboutWindow::AboutComponent::AboutComponent()
  */
 void AboutWindow::AboutComponent::setupLabels()
 {
-    using Initialiser = std::tuple<juce::Label*,
-                                   const juce::String,
-                                   float,
-                                   juce::Justification,
-                                   juce::Colour>;
+    using Initialiser = std::tuple<juce::Label*, const juce::String, float, juce::Justification, juce::Colour>;
 
+    const std::initializer_list<Initialiser> initList = {{&appNameLabel,
+                                                          juce::String(ProjectInfo::projectName),
+                                                          50,
+                                                          juce::Justification::bottomLeft,
+                                                          juce::Colour(225, 225, 225)},
+                                                         {&versionLabel,
+                                                          juce::String("Version ") + ProjectInfo::versionString,
+                                                          18,
+                                                          juce::Justification::topLeft,
+                                                          juce::Colour(180, 180, 180)},
+                                                         {&commitHashLabel,
+                                                          juce::String(GIT_COMMIT_HASH),
+                                                          10,
+                                                          juce::Justification::centredLeft,
+                                                          juce::Colour(120, 120, 120)}};
 
-    const std::initializer_list<Initialiser> initList = {
-        {&appNameLabel,
-         juce::String(ProjectInfo::projectName),
-         50,
-         juce::Justification::bottomLeft,
-         juce::Colour(225, 225, 225)},
-        {&versionLabel,
-         juce::String("Version ") + ProjectInfo::versionString,
-         18,
-         juce::Justification::topLeft,
-         juce::Colour(180, 180, 180)},
-        {&commitHashLabel,
-         juce::String(GIT_COMMIT_HASH),
-         10,
-         juce::Justification::centredLeft,
-         juce::Colour(120, 120, 120)}
-    };
-
-    for (const auto& [component, text, fontHeight, justification, textColour] :
-         initList)
+    for (const auto& [component, text, fontHeight, justification, textColour] : initList)
     {
         addAndMakeVisible(*component);
         component->setText(text, juce::dontSendNotification);

--- a/src/gui/windows/AboutWindow.cpp
+++ b/src/gui/windows/AboutWindow.cpp
@@ -20,7 +20,6 @@ AboutWindow::AboutWindow(std::shared_ptr<CommandManager> sharedCommandManager)
     setAlwaysOnTop(true);
     setVisible(true);
     setSize(430, 150);
-    toFront(false);
 
     setContentNonOwned(&aboutComponent, false);
 

--- a/src/gui/windows/AboutWindow.cpp
+++ b/src/gui/windows/AboutWindow.cpp
@@ -1,0 +1,190 @@
+/******************************************************************************
+ * @file   AboutWindow.cpp
+ * @author Tim Brewis (@t-bre, tab1g19@soton.ac.uk)
+ * @brief  'About' window
+ *****************************************************************************/
+
+#include "AboutWindow.h"
+
+namespace gui
+{
+
+/**
+ * @brief Constructor
+ */
+AboutWindow::AboutWindow(std::shared_ptr<CommandManager> sharedCommandManager)
+    : juce::DialogWindow("About", juce::Colours::white, true), commandManager(sharedCommandManager)
+{
+    setUsingNativeTitleBar(true);
+    setResizable(false, false);
+    setAlwaysOnTop(true);
+    setVisible(true);
+    setSize(430, 150);
+    toFront(false);
+
+    setContentNonOwned(&aboutComponent, false);
+
+    commandManager->registerAllCommandsForTarget(this);
+}
+
+/**
+ * @brief Implements juce::DialogWindow::paint()
+ */
+void AboutWindow::paint(juce::Graphics& g)
+{
+    g.fillAll(getLookAndFeel().findColour(backgroundColourId));
+}
+
+/**
+ * @brief Implements juce::DialogWindow::closeButtonPressed()
+ */
+void AboutWindow::closeButtonPressed()
+{
+    if (onCloseButtonPressed)
+    {
+        onCloseButtonPressed();
+    }
+}
+
+/**
+ * @brief Implements juce::ApplicationCommandTarget::getAllCommands()
+ */
+void AboutWindow::getAllCommands(juce::Array<juce::CommandID>& commands)
+{
+    std::initializer_list<juce::CommandID> targetCommands = {
+        CommandManager::CommandIDs::CloseWindow,
+    };
+
+    commands.addArray(targetCommands);
+}
+
+/**
+ * @brief Implements juce::ApplicationCommandTarget::getCommandInfo()
+ */
+void AboutWindow::getCommandInfo(juce::CommandID commandID,
+                                juce::ApplicationCommandInfo& result)
+{
+    switch (commandID)
+    {
+        case CommandManager::CloseWindow:
+        {
+            result.setInfo(juce::String("Close"),
+                           "Closes the window",
+                           CommandManager::CommandCategories::GUI,
+                           0);
+            result.defaultKeypresses.add(
+                juce::KeyPress('w', juce::ModifierKeys::commandModifier, 0));
+            break;
+        }
+
+        default:
+            break;
+    }
+}
+
+/**
+ * @brief Implements juce::ApplicationCommandTarget::perform()
+ */
+bool AboutWindow::perform(const InvocationInfo& info)
+{
+    switch (info.commandID)
+    {
+        case CommandManager::CloseWindow:
+        {
+            closeButtonPressed();
+            break;
+        }
+
+        default:
+            return false;
+    }
+
+    return true;
+}
+
+/**
+ * @brief Implements juce::ApplicationCommandTarget::getNextCommandTarget() 
+ */
+juce::ApplicationCommandTarget* AboutWindow::getNextCommandTarget()
+{
+    return nullptr;
+}
+
+/**
+ * @brief Constructor for internal content component
+ */
+AboutWindow::AboutComponent::AboutComponent()
+{
+    setupLabels();
+
+    appIconImage.setImage(juce::ImageCache::getFromMemory(
+        BinaryData::AppIcon_1024_png, BinaryData::AppIcon_1024_pngSize));
+
+    addAndMakeVisible(appIconImage);
+}
+
+/**
+ * @brief Sets up static label content
+ */
+void AboutWindow::AboutComponent::setupLabels()
+{
+    using Initialiser = std::tuple<juce::Label*,
+                                   const juce::String,
+                                   float,
+                                   juce::Justification,
+                                   juce::Colour>;
+
+    juce::String version("Version ");
+    version += ProjectInfo::versionString;
+
+    juce::String name(ProjectInfo::projectName);
+
+    const std::initializer_list<Initialiser> initList = {
+        {&appNameLabel,
+         name,
+         50,
+         juce::Justification::bottomLeft,
+         juce::Colour(225, 225, 225)},
+        {&versionLabel,
+         version,
+         18,
+         juce::Justification::topLeft,
+         juce::Colour(180, 180, 180)}
+    };
+
+    for (const auto& [component, text, fontHeight, justification, textColour] :
+         initList)
+    {
+        addAndMakeVisible(*component);
+        component->setText(text, juce::dontSendNotification);
+        component->setJustificationType(justification);
+        component->setFont(component->getFont().withHeight(fontHeight));
+        component->setColour(component->textColourId, textColour);
+    }
+}
+
+/**
+ * @brief Implements juce::Component::resized()
+ */
+void AboutWindow::AboutComponent::resized()
+{
+    auto bounds = getLocalBounds();
+    int height = bounds.getHeight();
+
+    // app icon
+    auto iconBounds = bounds.removeFromLeft(height);
+    appIconImage.setBounds(iconBounds.reduced(appIconBorder));
+
+    // app name
+    auto nameBounds = bounds.removeFromTop(height / 2);
+    appNameLabel.setBounds(nameBounds);
+
+    // app version
+    int offset = 4;
+    auto versionBounds = bounds.removeFromTop(height / 5);
+    versionBounds.setY(versionBounds.getY() - offset);
+    versionBounds.setX(versionBounds.getX() + offset);
+    versionLabel.setBounds(versionBounds);
+}
+
+} // namespace gui

--- a/src/gui/windows/AboutWindow.cpp
+++ b/src/gui/windows/AboutWindow.cpp
@@ -19,10 +19,11 @@ AboutWindow::AboutWindow(std::shared_ptr<CommandManager> sharedCommandManager)
     setResizable(false, false);
     setAlwaysOnTop(true);
     setVisible(true);
-    setSize(430, 150);
+    setSize(400, 150);
 
     setContentNonOwned(&aboutComponent, false);
 
+    jassert(commandManager);
     commandManager->registerAllCommandsForTarget(this);
 }
 
@@ -133,22 +134,23 @@ void AboutWindow::AboutComponent::setupLabels()
                                    juce::Justification,
                                    juce::Colour>;
 
-    juce::String version("Version ");
-    version += ProjectInfo::versionString;
-
-    juce::String name(ProjectInfo::projectName);
 
     const std::initializer_list<Initialiser> initList = {
         {&appNameLabel,
-         name,
+         juce::String(ProjectInfo::projectName),
          50,
          juce::Justification::bottomLeft,
          juce::Colour(225, 225, 225)},
         {&versionLabel,
-         version,
+         juce::String("Version ") + ProjectInfo::versionString,
          18,
          juce::Justification::topLeft,
-         juce::Colour(180, 180, 180)}
+         juce::Colour(180, 180, 180)},
+        {&commitHashLabel,
+         juce::String(GIT_COMMIT_HASH),
+         10,
+         juce::Justification::centredLeft,
+         juce::Colour(120, 120, 120)}
     };
 
     for (const auto& [component, text, fontHeight, justification, textColour] :
@@ -168,22 +170,29 @@ void AboutWindow::AboutComponent::setupLabels()
 void AboutWindow::AboutComponent::resized()
 {
     auto bounds = getLocalBounds();
-    int height = bounds.getHeight();
 
     // app icon
-    auto iconBounds = bounds.removeFromLeft(height);
+    auto iconBounds = bounds.removeFromLeft(bounds.getHeight());
     appIconImage.setBounds(iconBounds.reduced(appIconBorder));
 
     // app name
-    auto nameBounds = bounds.removeFromTop(height / 2);
+    auto h = bounds.getHeight();
+    bounds.removeFromTop(h / 4);
+    bounds.removeFromBottom(h / 6);
+
+    auto nameBounds = bounds.removeFromTop(bounds.getHeight() / 2);
     appNameLabel.setBounds(nameBounds);
 
     // app version
     int offset = 4;
-    auto versionBounds = bounds.removeFromTop(height / 5);
-    versionBounds.setY(versionBounds.getY() - offset);
-    versionBounds.setX(versionBounds.getX() + offset);
+    auto versionBounds = bounds.removeFromTop(bounds.getHeight() / 2);
+    versionBounds.removeFromLeft(offset);
     versionLabel.setBounds(versionBounds);
+
+    // commit hash
+    auto hashBounds = bounds.removeFromTop(bounds.getHeight() / 2);
+    hashBounds.removeFromLeft(offset);
+    commitHashLabel.setBounds(hashBounds);
 }
 
 } // namespace gui

--- a/src/gui/windows/AboutWindow.h
+++ b/src/gui/windows/AboutWindow.h
@@ -29,8 +29,7 @@ public:
 
     // command handling
     void getAllCommands(juce::Array<juce::CommandID>& commands) override;
-    void getCommandInfo(juce::CommandID commandID,
-                        juce::ApplicationCommandInfo& result) override;
+    void getCommandInfo(juce::CommandID commandID, juce::ApplicationCommandInfo& result) override;
     bool perform(const InvocationInfo& info) override;
     juce::ApplicationCommandTarget* getNextCommandTarget() override;
 

--- a/src/gui/windows/AboutWindow.h
+++ b/src/gui/windows/AboutWindow.h
@@ -1,0 +1,69 @@
+/******************************************************************************
+ * @file   AboutWindow.h
+ * @author Tim Brewis (@t-bre, tab1g19@soton.ac.uk)
+ * @brief  'About' window
+ *****************************************************************************/
+
+#pragma once
+
+#include "../../CommandManager.h"
+#include <JuceHeader.h>
+#include <functional>
+#include <memory>
+
+namespace gui
+{
+
+/**
+ * @brief 'About' window
+ */
+
+class AboutWindow : public juce::DialogWindow, public juce::ApplicationCommandTarget
+{
+public:
+
+    AboutWindow(std::shared_ptr<CommandManager> sharedCommandManager);
+
+    // graphics
+    void paint(juce::Graphics& g) override;
+
+    // command handling
+    void getAllCommands(juce::Array<juce::CommandID>& commands) override;
+    void getCommandInfo(juce::CommandID commandID,
+                        juce::ApplicationCommandInfo& result) override;
+    bool perform(const InvocationInfo& info) override;
+    juce::ApplicationCommandTarget* getNextCommandTarget() override;
+
+    // window controls
+    void closeButtonPressed() override;
+    std::function<void()> onCloseButtonPressed;
+
+private:
+
+    /**
+     * @brief Internal content component class
+     */
+    class AboutComponent : public juce::Component
+    {
+    public:
+
+        AboutComponent();
+
+        void resized() override;
+
+    private:
+
+        void setupLabels();
+
+        juce::Label appNameLabel;
+        juce::Label versionLabel;
+        juce::ImageComponent appIconImage;
+
+        const int appIconBorder = 12;
+    };
+
+    AboutComponent aboutComponent;
+    std::shared_ptr<CommandManager> commandManager;
+};
+
+} // namespace gui

--- a/src/gui/windows/AboutWindow.h
+++ b/src/gui/windows/AboutWindow.h
@@ -57,6 +57,7 @@ private:
 
         juce::Label appNameLabel;
         juce::Label versionLabel;
+        juce::Label commitHashLabel;
         juce::ImageComponent appIconImage;
 
         const int appIconBorder = 12;

--- a/src/gui/windows/MainWindow.cpp
+++ b/src/gui/windows/MainWindow.cpp
@@ -36,7 +36,7 @@ MainWindow::MainWindow(const juce::String& name,
 
     jassert(commandManager);
     commandManager->registerAllCommandsForTarget(this);
-    commandManager->setFirstCommandTarget(this);
+    addKeyListener(commandManager->getKeyMappings());
 }
 
 /**

--- a/src/gui/windows/MainWindow.h
+++ b/src/gui/windows/MainWindow.h
@@ -19,7 +19,7 @@ namespace gui
 /**
  * @brief Main GUI window
  */
-class MainWindow : public juce::DocumentWindow, juce::ApplicationCommandTarget
+class MainWindow : public juce::DocumentWindow, public juce::ApplicationCommandTarget
 {
 public:
 


### PR DESCRIPTION
## Description
- Creates an 'About' window showing the application name and version information.
- The window is accessed through the menu bar.
- `GIT_COMMIT_HASH` string is now available as a pre-processor definition.

Closes #67 

## Checklist
- [x] Code linted with `trunk check`
- [x] Code formatted with `trunk fmt`
- [x] Changes do not generate any new compiler warnings 
- [x] Commit messages follow the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
