### PR TITLE
build: remove dash from app title

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,7 +4,7 @@
             "name": "(lldb) Launch",
             "type": "cppdbg",
             "request": "launch",
-            "program": "${workspaceFolder}/build/VCU-GUI_artefacts/Debug/VCU-GUI.app/Contents/MacOS/VCU-GUI",
+            "program": "${workspaceFolder}/build/VCU-GUI_artefacts/Debug/VCU GUI.app/Contents/MacOS/VCU GUI",
             "args": [],
             "stopAtEntry": false,
             "cwd": "${fileDirname}",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,9 +22,9 @@ set(TARGET_NAME ${PROJECT_NAME})
 add_subdirectory(lib/JUCE)
 
 juce_add_gui_app(${TARGET_NAME}
-    PRODUCT_NAME "${PROJECT_NAME}"
+    PRODUCT_NAME "VCU GUI"
     COMPANY_NAME "SUFST"
-    BUNDLE_ID "com.sufst.${PROJECT_NAME}"
+    BUNDLE_ID "com.sufst.vcu-gui"
     ICON_SMALL res/AppIcon_512.png
     ICON_LARGE res/AppIcon_1024.png
 )


### PR DESCRIPTION
## Description
- 'VCU-GUI' -> 'VCU GUI'.
- The CMake target is still `VCU-GUI`.

Closes #69 

## Checklist
- [x] Code linted with `trunk check`
- [x] Code formatted with `trunk fmt`
- [x] Changes do not generate any new compiler warnings 
- [x] Commit messages follow the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
