### PR TITLE
feat(gui): add points scaling slider

### DIFF
--- a/src/ConfigurationValueTree.h
+++ b/src/ConfigurationValueTree.h
@@ -42,6 +42,7 @@ public:
         inline static const juce::Identifier InterpolationMethod = "InterpolationMethod";
         inline static const juce::Identifier InputValue = "InputValue";
         inline static const juce::Identifier OutputValue = "OutputValue";
+        inline static const juce::Identifier ScaleFactor = "ScaleFactor";
 
     private:
 

--- a/src/gui/components/MainComponent.cpp
+++ b/src/gui/components/MainComponent.cpp
@@ -24,12 +24,14 @@ MainComponent::MainComponent(std::shared_ptr<ConfigurationValueTree> sharedConfi
 
     setupInterpolationCombo();
     setupButtons();
+    setupSliders();
 
     addAndMakeVisible(torqueMapGraph);
     addAndMakeVisible(interpolationCombo);
     addAndMakeVisible(exportProfileButton);
     addAndMakeVisible(importProfileButton);
     addAndMakeVisible(exportCodeButton);
+    addAndMakeVisible(pointsScaleSlider);
 }
 
 /**
@@ -162,9 +164,20 @@ void MainComponent::setupButtons()
 }
 
 /**
- * @brief Painter
- *
- * @param[in]   g   Graphics context
+ * @brief Sets up slider components
+ */
+void MainComponent::setupSliders()
+{
+    // points scale factor
+    pointsScaleSlider.setSliderStyle(juce::Slider::SliderStyle::LinearBarVertical);
+    pointsScaleSlider.setRange(0.0, 1.0);
+    pointsScaleSlider.setNumDecimalPlacesToDisplay(2);
+    pointsScaleSlider.setTextBoxStyle(juce::Slider::NoTextBox, true, 0, 0);
+    pointsScaleSlider.setValue(1.0, juce::dontSendNotification);
+}
+
+/**
+ * @brief Implements juce::Component::paint()
  */
 void MainComponent::paint(juce::Graphics& g)
 {
@@ -189,7 +202,8 @@ void MainComponent::resized()
     footer.removeFromTop(10);
     footer.removeFromBottom(2);
 
-    // graph
+    // graph and slider
+    pointsScaleSlider.setBounds(bounds.removeFromRight(20));
     torqueMapGraph.setBounds(bounds);
 
     // footer

--- a/src/gui/components/MainComponent.cpp
+++ b/src/gui/components/MainComponent.cpp
@@ -174,6 +174,12 @@ void MainComponent::setupSliders()
     pointsScaleSlider.setNumDecimalPlacesToDisplay(2);
     pointsScaleSlider.setTextBoxStyle(juce::Slider::NoTextBox, true, 0, 0);
     pointsScaleSlider.setValue(1.0, juce::dontSendNotification);
+
+    pointsScaleSlider.onValueChange = [this]() {
+        double scaleFactor = pointsScaleSlider.getValue();
+        auto torqueMap = this->configValueTree->getChildWithName(ConfigurationValueTree::Children::TorqueMap);
+        torqueMap.setProperty(ConfigurationValueTree::Properties::ScaleFactor, scaleFactor, nullptr);
+    };
 }
 
 /**

--- a/src/gui/components/MainComponent.h
+++ b/src/gui/components/MainComponent.h
@@ -41,6 +41,7 @@ private:
 
     void setupInterpolationCombo();
     void setupButtons();
+    void setupSliders();
 
     // shared config state
     std::shared_ptr<ConfigurationValueTree> configValueTree;
@@ -58,6 +59,7 @@ private:
     juce::TextButton exportProfileButton;
     juce::TextButton importProfileButton;
     juce::TextButton exportCodeButton;
+    juce::Slider pointsScaleSlider;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MainComponent)
 };

--- a/src/gui/components/TorqueMapComponent.h
+++ b/src/gui/components/TorqueMapComponent.h
@@ -35,6 +35,8 @@ public:
 
 private:
 
+    void paintScaledCurve(juce::Graphics& g);
+
     // deadzone drawing
     juce::Rectangle<int> getDeadzoneBounds() const;
     void paintDeadzoneOverlay(juce::Graphics& g) const;
@@ -53,7 +55,8 @@ private:
 
     std::shared_ptr<ConfigurationValueTree> configValueTree;
 
-    // constant data
+    // torque map data
+    float scaleFactor = 1;
     // TODO: this needs to be part of the torque map
     static const int inputResolution = 10;
     static const int outputResolution = 15;
@@ -61,6 +64,7 @@ private:
     static const int outputMax = (1 << outputResolution) - 1;
 
     const juce::Colour deadzoneColour = sufst::Colours::skyblue;
+    const juce::Colour scaledLineColour = sufst::Colours::skyblue.withAlpha(0.2f);
 };
 
 } // namespace gui


### PR DESCRIPTION
## Description
- Adds a slider to scale all points on the torque curve.
- The scaled curve is drawn lightly underneath the actual curve. This allows the full graph bounds to still be used for editing points while also showing the final curve.

Closes #47 

## Checklist
- [ ] Code linted with `trunk check`
- [ ] Code formatted with `trunk fmt`
- [ ] Changes do not generate any new compiler warnings 
- [ ] Commit messages follow the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
