### PR TITLE
chore: clean up for next development cycle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@
 compile_commands.json
 
 # vscode
-.vscode
+.vscode/*
 !.vscode/launch.json
 !.vscode/settings.json 
 !.vscode/tasks.json 

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,26 +1,26 @@
 {
-    "configurations": [
-        {
-            "name": "Mac (ARM)",
-            "includePath": [
-                "${workspaceFolder}/src/**",
-                "${workspaceFolder}/lib/JUCE/modules/**",
-                "${workspaceFolder}/build/VCU-GUI_artefacts/JuceLibraryCode/**",
-                "${workspaceFolder}/lib/JUCE/modules",
-                "${workspaceFolder}/lib/spline/src"
-            ],
-            "defines": [],
-            "compilerPath": "/usr/bin/clang",
-            "cStandard": "c17",
-            "cppStandard": "c++17",
-            "intelliSenseMode": "macos-clang-arm64",
-            "browse": {
-                "limitSymbolsToIncludedHeaders": true,
-                "databaseFilename": ""
-            },
-            "compileCommands": "${workspaceFolder}/compile_commands.json",
-            "configurationProvider": "ms-vscode.cmake-tools"
-        }
-    ],
-    "version": 4
+  "configurations": [
+    {
+      "name": "Mac (ARM)",
+      "includePath": [
+        "${workspaceFolder}/src/**",
+        "${workspaceFolder}/lib/JUCE/modules/**",
+        "${workspaceFolder}/build/VCU-GUI_artefacts/JuceLibraryCode/**",
+        "${workspaceFolder}/lib/JUCE/modules",
+        "${workspaceFolder}/lib/spline/src"
+      ],
+      "defines": [],
+      "compilerPath": "/usr/bin/clang",
+      "cStandard": "c17",
+      "cppStandard": "c++17",
+      "intelliSenseMode": "macos-clang-arm64",
+      "browse": {
+        "limitSymbolsToIncludedHeaders": true,
+        "databaseFilename": ""
+      },
+      "compileCommands": "${workspaceFolder}/compile_commands.json",
+      "configurationProvider": "ms-vscode.cmake-tools"
+    }
+  ],
+  "version": 4
 }

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -10,9 +10,6 @@
                 "${workspaceFolder}/lib/spline/src"
             ],
             "defines": [],
-            "macFrameworkPath": [
-                "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks"
-            ],
             "compilerPath": "/usr/bin/clang",
             "cStandard": "c17",
             "cppStandard": "c++17",

--- a/src/ConfigurationValueTree.cpp
+++ b/src/ConfigurationValueTree.cpp
@@ -94,68 +94,6 @@ std::unique_ptr<juce::XmlDocument> ConfigurationValueTree::exportXml() const
 }
 
 /**
- * @brief Exports all auto-generated code required to implement the configuration on the VCU
- *
- * @note  TODO: this is temporary and needs a serious rewrite!
- */
-juce::String ConfigurationValueTree::exportCode() const
-{
-    juce::ValueTree torqueMap = tree.getChildWithName(Children::TorqueMap);
-
-    // extract points from the torque map, filling with leading zeros
-    juce::Array<juce::Point<int>> points;
-
-    for (const auto& child : torqueMap)
-    {
-        if (child.isValid() && child.hasType(Children::TorqueMapPoint))
-        {
-            const int input = child.getProperty(Properties::InputValue);
-            const int output = child.getProperty(Properties::OutputValue);
-
-            points.add({input, output});
-        }
-    }
-
-    for (int i = 0; i < points[i].getX(); i++)
-    {
-        points.add({i, 0});
-    }
-
-    // run interpolator
-    juce::String interpolationMethod = torqueMap.getProperty(Properties::InterpolationMethod);
-    auto interpolator = InterpolatorFactory<int>::makeInterpolator(interpolationMethod);
-
-    interpolator->process(points, points.getLast().getX());
-
-    // produce code
-    juce::String code = "const uint32_t torque_map[] = {\n\t";
-
-    int rowIndex = 0;
-    const int itemsPerRow = 8;
-
-    for (const auto& point : interpolator->getInterpolatedPoints())
-    {
-        juce::String hex = juce::String::toHexString(point.getY());
-        int leadingZeros = 4 - hex.length();
-        hex = juce::String::repeatedString("0", leadingZeros) + hex;
-
-        code += "0x" + hex + ", ";
-
-        rowIndex++;
-
-        if (rowIndex == itemsPerRow)
-        {
-            code += "\n\t";
-            rowIndex = 0;
-        }
-    }
-
-    code = code.substring(0, code.length() - 1); // remove last \t
-    code += "};\n";
-    return code;
-}
-
-/**
  * @brief       Load a configuration from a file
  *
  * @note        This will cause juce::ValueTree::Listener objects registered with addListener() to receive the

--- a/src/ConfigurationValueTree.h
+++ b/src/ConfigurationValueTree.h
@@ -23,7 +23,6 @@ public:
     juce::ValueTree getChildWithName(const juce::Identifier& identifier) const;
 
     std::unique_ptr<juce::XmlDocument> exportXml() const;
-    juce::String exportCode() const;
     void loadFromFile(const juce::File& file);
     static juce::ValueTree createTorqueMapPoint(int input, int output);
 

--- a/src/gui/components/MainComponent.cpp
+++ b/src/gui/components/MainComponent.cpp
@@ -29,7 +29,6 @@ MainComponent::MainComponent(std::shared_ptr<ConfigurationValueTree> sharedConfi
     addAndMakeVisible(interpolationCombo);
     addAndMakeVisible(exportProfileButton);
     addAndMakeVisible(importProfileButton);
-    addAndMakeVisible(exportCodeButton);
 }
 
 /**
@@ -130,35 +129,6 @@ void MainComponent::setupButtons()
                                      configValueTree->loadFromFile(chooser.getResult());
                                  });
     };
-
-    // export code
-    exportCodeButton.setButtonText("Export Code");
-
-    exportCodeButton.onClick = [this]()
-    {
-        fileChooser = std::make_unique<juce::FileChooser>("Export Code",
-                                                          juce::File::getSpecialLocation(juce::File::userHomeDirectory),
-                                                          "*.c",
-                                                          true);
-
-        auto fileChooserFlags = juce::FileBrowserComponent::canSelectFiles
-                                | juce::FileBrowserComponent::warnAboutOverwriting
-                                | juce::FileBrowserComponent::saveMode;
-
-        fileChooser->launchAsync(fileChooserFlags,
-                                 [this](const juce::FileChooser& chooser)
-                                 {
-                                     if (chooser.getResults().isEmpty())
-                                     {
-                                         return;
-                                     }
-
-                                     juce::String code = configValueTree->exportCode();
-                                     auto file = chooser.getResult();
-
-                                     file.replaceWithText(code);
-                                 });
-    };
 }
 
 /**
@@ -194,7 +164,7 @@ void MainComponent::resized()
 
     // footer
     std::initializer_list<juce::Component*> footerComponents
-        = {&interpolationCombo, &exportProfileButton, &importProfileButton, &exportCodeButton};
+        = {&interpolationCombo, &exportProfileButton, &importProfileButton};
 
     const int numFooterComponents = static_cast<int>(footerComponents.size());
     const int footerItemSpacing = borderSize / numFooterComponents;

--- a/src/gui/components/MainComponent.h
+++ b/src/gui/components/MainComponent.h
@@ -57,7 +57,6 @@ private:
     juce::ComboBox interpolationCombo;
     juce::TextButton exportProfileButton;
     juce::TextButton importProfileButton;
-    juce::TextButton exportCodeButton;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MainComponent)
 };


### PR DESCRIPTION
## Description
- Remove the code export functionality. This was broken and will be replaced with a system for directly communicating with the VCU.

## Checklist
- [x] Code linted with `trunk check`
- [x] Code formatted with `trunk fmt`
- [x] Changes do not generate any new compiler warnings 
- [x] Commit messages follow the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
