### PR TITLE
build(windows): fix missing definition of `M_PI`

### DIFF
--- a/.trunk/config/.clang-format
+++ b/.trunk/config/.clang-format
@@ -58,6 +58,7 @@ SpaceBeforeSquareBrackets: false
 SpacesInCStyleCastParentheses: false
 SpacesInConditionalStatement: false
 SpacesInParentheses: false
+IndentPPDirectives: BeforeHash
 
 # braces
 BraceWrapping:

--- a/src/Interpolator.h
+++ b/src/Interpolator.h
@@ -8,15 +8,28 @@
 
 #include <JuceHeader.h>
 
-#pragma GCC diagnostic push // disable warnings from external spline library
-#pragma GCC diagnostic ignored "-Wconversion"
-#pragma GCC diagnostic ignored "-Wextra-semi"
-#pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#pragma GCC diagnostic ignored "-Wc++98-compat-extra-semi"
-#define NDEBUG // prevent assert()
-#include <spline.h>
-#undef NDEBUG
-#pragma GCC diagnostic pop
+#if (JUCE_MAC || JUCE_LINUX)
+    #pragma GCC diagnostic push // disable warnings from external spline library
+    #pragma GCC diagnostic ignored "-Wconversion"
+    #pragma GCC diagnostic ignored "-Wextra-semi"
+    #pragma GCC diagnostic ignored "-Wmissing-prototypes"
+    #pragma GCC diagnostic ignored "-Wc++98-compat-extra-semi"
+#elif (JUCE_WINDOWS)
+    // TODO: add MSVC equivalent pragmas
+    #define M_PI juce::MathConstants<float>::pi
+#endif
+
+#ifndef NDEBUG
+    #define NDEBUG // prevent assert()
+    #include <spline.h>
+    #undef NDEBUG
+#else
+    #include <spline.h>
+#endif
+
+#if (JUCE_MAC || JUCE_LINUX)
+    #pragma GCC diagnostic pop
+#endif
 
 #include "utility/linspace.h"
 #include <algorithm>


### PR DESCRIPTION
## Description

- Adds definition of `M_PI` when building on Windows.
- This is needed by `spline.h`.
- Build should now work with no errors on Windows.

Closes #96 

## Checklist

- [x] Code linted with `trunk check`
- [x] Code formatted with `trunk fmt`
- [x] Changes do not generate any new compiler warnings
- [x] Commit messages follow the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
