### PR TITLE
chore: update formatting

### DIFF
--- a/.trunk/config/.clang-format
+++ b/.trunk/config/.clang-format
@@ -15,7 +15,7 @@ Language: Cpp
 IndentWidth: 4
 TabWidth: 4
 UseTab: Never
-ColumnLimit: 120
+ColumnLimit: 80
 
 # alignment
 AccessModifierOffset: -4

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -12,10 +12,11 @@ runtimes:
     - node@16.14.2
 lint:
   enabled:
-    - git-diff-check
     - gitleaks@8.15.0
     - clang-tidy@14.0.0
     - clang-format@13.0.0
+  disabled:
+    - git-diff-check
   ignore:
     - linters: [ALL]
       paths:

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -18,7 +18,9 @@ void Application::initialise(const juce::String& /*commandLine*/)
     commandManager = std::make_shared<CommandManager>();
     commandManager->registerAllCommandsForTarget(this);
 
-    mainWindow = std::make_unique<gui::MainWindow>(getApplicationName(), configValueTree, commandManager);
+    mainWindow = std::make_unique<gui::MainWindow>(getApplicationName(),
+                                                   configValueTree,
+                                                   commandManager);
 
     LookAndFeel::setDefaultLookAndFeel(&lookAndFeel);
 }

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -77,9 +77,10 @@ bool Application::moreThanOneInstanceAllowed()
 /**
  * @brief   Implements juce::ApplicationCommandTarget::getNextCommandTarget()
  *
- * @details This ensures that the main window is found as a target by the CommandManager when the app launches. Without
- *          this, if the user does not interact with a component inside the main window, menu bar items will be greyed
- *          out (though keyboard shortcuts will still work).
+ * @details This ensures that the main window is found as a target by the
+ * CommandManager when the app launches. Without this, if the user does not
+ * interact with a component inside the main window, menu bar items will be
+ * greyed out (though keyboard shortcuts will still work).
  */
 juce::ApplicationCommandTarget* Application::getNextCommandTarget()
 {

--- a/src/ConfigurationValueTree.cpp
+++ b/src/ConfigurationValueTree.cpp
@@ -42,8 +42,9 @@ juce::ValueTree ConfigurationValueTree::createEmptyConfiguration()
 /**
  * @brief   Adds a listener to the root juce::ValueTree
  *
- * @note    This should be used to register juce::ValueTree::Listener objects as it adds a listener to the root value
- *          tree owned by this object. If getRoot().addListener() or similar is used, when a new profile is loaded the
+ * @note    This should be used to register juce::ValueTree::Listener objects as
+ * it adds a listener to the root value tree owned by this object. If
+ * getRoot().addListener() or similar is used, when a new profile is loaded the
  *          valueTreeRedirected() callback will not be called!
  */
 void ConfigurationValueTree::addListener(juce::ValueTree::Listener* newListener)
@@ -60,7 +61,8 @@ juce::ValueTree ConfigurationValueTree::getRoot() const
 }
 
 /**
- * @brief       Returns the first child tree with the specified name, if it exists
+ * @brief       Returns the first child tree with the specified name, if it
+ * exists
  *
  * @param[in]   identifier  Identifier name of the child
  */
@@ -96,8 +98,9 @@ std::unique_ptr<juce::XmlDocument> ConfigurationValueTree::exportXml() const
 /**
  * @brief       Load a configuration from a file
  *
- * @note        This will cause juce::ValueTree::Listener objects registered with addListener() to receive the
- *              valueTreeRedirected() callback which should handle loading of a new profile
+ * @note        This will cause juce::ValueTree::Listener objects registered
+ * with addListener() to receive the valueTreeRedirected() callback which should
+ * handle loading of a new profile
  *
  * @param[in]   xml     XML document
  */

--- a/src/ConfigurationValueTree.cpp
+++ b/src/ConfigurationValueTree.cpp
@@ -14,7 +14,8 @@ using utility::LinearInterpolator;
 /**
  * @brief Default constructor
  */
-ConfigurationValueTree::ConfigurationValueTree() : tree(createEmptyConfiguration())
+ConfigurationValueTree::ConfigurationValueTree()
+    : tree(createEmptyConfiguration())
 {
     DBG(tree.toXmlString());
 }
@@ -30,9 +31,10 @@ juce::ValueTree ConfigurationValueTree::createEmptyConfiguration()
     rootTree.addChild(torqueMapTree, 0, nullptr);
     rootTree.setProperty(Properties::ProfileName, "New Profile", nullptr);
 
-    torqueMapTree.setProperty(Properties::InterpolationMethod,
-                              utility::SplineInterpolator<int>::identifier.toString(),
-                              nullptr);
+    torqueMapTree.setProperty(
+        Properties::InterpolationMethod,
+        utility::SplineInterpolator<int>::identifier.toString(),
+        nullptr);
     torqueMapTree.addChild(createTorqueMapPoint(0, 0), 0, nullptr);
     torqueMapTree.addChild(createTorqueMapPoint(1023, 32767), 1, nullptr);
 
@@ -66,7 +68,8 @@ juce::ValueTree ConfigurationValueTree::getRoot() const
  *
  * @param[in]   identifier  Identifier name of the child
  */
-juce::ValueTree ConfigurationValueTree::getChildWithName(const juce::Identifier& identifier) const
+juce::ValueTree ConfigurationValueTree::getChildWithName(
+    const juce::Identifier& identifier) const
 {
     return tree.getChildWithName(identifier);
 }
@@ -77,7 +80,8 @@ juce::ValueTree ConfigurationValueTree::getChildWithName(const juce::Identifier&
  * @param[in]   input   Input value
  * @param[in]   output  Output value (input -> torque map -> output)
  */
-juce::ValueTree ConfigurationValueTree::createTorqueMapPoint(int input, int output)
+juce::ValueTree ConfigurationValueTree::createTorqueMapPoint(int input,
+                                                             int output)
 {
     juce::ValueTree point(Children::TorqueMapPoint);
 

--- a/src/ConfigurationValueTree.h
+++ b/src/ConfigurationValueTree.h
@@ -36,10 +36,12 @@ public:
 
         // metadata
         inline static const juce::Identifier ProfileName = "ProfileName";
-        inline static const juce::Identifier ApplicationVersion = "ApplicationVersion";
+        inline static const juce::Identifier ApplicationVersion
+            = "ApplicationVersion";
 
         // torque map
-        inline static const juce::Identifier InterpolationMethod = "InterpolationMethod";
+        inline static const juce::Identifier InterpolationMethod
+            = "InterpolationMethod";
         inline static const juce::Identifier InputValue = "InputValue";
         inline static const juce::Identifier OutputValue = "OutputValue";
 

--- a/src/ConfigurationValueTree.h
+++ b/src/ConfigurationValueTree.h
@@ -10,7 +10,8 @@
 #include <memory>
 
 /**
- * @brief Stores the VCU configuration profile and notifies registered listeners when it changes
+ * @brief Stores the VCU configuration profile and notifies registered listeners
+ * when it changes
  */
 class ConfigurationValueTree final
 {

--- a/src/Interpolator.h
+++ b/src/Interpolator.h
@@ -62,7 +62,9 @@ public:
      * @param[in]   inputSamples        Input samples
      * @param[in]   numOutputSamples    The number of output samples to generate
      */
-    virtual void process(const juce::Array<juce::Point<ValueType>>& inputSamples, int numOutputSamples)
+    virtual void
+    process(const juce::Array<juce::Point<ValueType>>& inputSamples,
+            int numOutputSamples)
     {
         jassert(inputSamples.size() >= 2);
 
@@ -71,15 +73,17 @@ public:
             prepare(inputSamples);
             this->resetSamples(numOutputSamples);
 
-            auto outputX
-                = linspace<ValueType>(inputSamples.getFirst().getX(), inputSamples.getLast().getX(), numOutputSamples);
+            auto outputX = linspace<ValueType>(inputSamples.getFirst().getX(),
+                                               inputSamples.getLast().getX(),
+                                               numOutputSamples);
 
             int leftIndex = 0;
             int rightIndex = 1;
 
             for (const auto& x : outputX)
             {
-                while (x >= inputSamples[rightIndex].getX() && rightIndex != inputSamples.size())
+                while (x >= inputSamples[rightIndex].getX()
+                       && rightIndex != inputSamples.size())
                 {
                     leftIndex++;
                     rightIndex++;
@@ -128,7 +132,9 @@ protected:
      * @param[in]   rightPoint  Nearest point with x-coordinate to right of
      * input
      */
-    virtual ValueType interpolate(ValueType input, juce::Point<ValueType> leftPoint, juce::Point<ValueType> rightPoint)
+    virtual ValueType interpolate(ValueType input,
+                                  juce::Point<ValueType> leftPoint,
+                                  juce::Point<ValueType> rightPoint)
         = 0;
 
     /**
@@ -137,7 +143,9 @@ protected:
      *
      * @param[in]   inputSamples    The input samples for interpolation
      */
-    virtual void prepare(const juce::Array<juce::Point<ValueType>>& inputSamples) = 0;
+    virtual void
+    prepare(const juce::Array<juce::Point<ValueType>>& inputSamples)
+        = 0;
 
     /**
      * @brief       Validates or invalidates the cache
@@ -197,7 +205,8 @@ public:
     /**
      * @brief Implements Interpolator::prepare()
      */
-    void prepare(const juce::Array<juce::Point<ValueType>>& /*inputSamples*/) override
+    void prepare(
+        const juce::Array<juce::Point<ValueType>>& /*inputSamples*/) override
     {
         // nothing to do
     }
@@ -205,10 +214,14 @@ public:
     /**
      * @brief Implements Interpolator::interpolate()
      */
-    ValueType interpolate(ValueType input, juce::Point<ValueType> leftPoint, juce::Point<ValueType> rightPoint) override
+    ValueType interpolate(ValueType input,
+                          juce::Point<ValueType> leftPoint,
+                          juce::Point<ValueType> rightPoint) override
     {
-        const auto xDiff = static_cast<float>(rightPoint.getX() - leftPoint.getX());
-        const auto yDiff = static_cast<float>(rightPoint.getY() - leftPoint.getY());
+        const auto xDiff
+            = static_cast<float>(rightPoint.getX() - leftPoint.getX());
+        const auto yDiff
+            = static_cast<float>(rightPoint.getY() - leftPoint.getY());
         const auto inDiff = static_cast<float>(input - leftPoint.getX());
 
         const double mu = inDiff / xDiff;
@@ -238,7 +251,8 @@ public:
     /**
      * @brief Implements Interpolator::prepare()
      */
-    void prepare(const juce::Array<juce::Point<ValueType>>& /*inputSamples*/) override
+    void prepare(
+        const juce::Array<juce::Point<ValueType>>& /*inputSamples*/) override
     {
         // nothing to do
     }
@@ -246,14 +260,18 @@ public:
     /**
      * @brief Implements Interpolator::interpolate()
      */
-    ValueType interpolate(ValueType input, juce::Point<ValueType> leftPoint, juce::Point<ValueType> rightPoint) override
+    ValueType interpolate(ValueType input,
+                          juce::Point<ValueType> leftPoint,
+                          juce::Point<ValueType> rightPoint) override
     {
         const ValueType xDiff = rightPoint.getX() - leftPoint.getX();
 
         const double mu = static_cast<double>(input - leftPoint.getX()) / xDiff;
-        const double mu2 = (1 - std::cos(mu * juce::MathConstants<double>::pi)) / 2;
+        const double mu2
+            = (1 - std::cos(mu * juce::MathConstants<double>::pi)) / 2;
 
-        return static_cast<ValueType>(leftPoint.getY() * (1 - mu2) + rightPoint.getY() * mu2);
+        return static_cast<ValueType>(leftPoint.getY() * (1 - mu2)
+                                      + rightPoint.getY() * mu2);
     }
 
     /**
@@ -278,7 +296,8 @@ public:
     /**
      * @brief Implements Interpolator::prepare()
      */
-    void prepare(const juce::Array<juce::Point<ValueType>>& inputSamples) override
+    void
+    prepare(const juce::Array<juce::Point<ValueType>>& inputSamples) override
     {
         const size_t numInputSamples = static_cast<size_t>(inputSamples.size());
 
@@ -299,14 +318,17 @@ public:
             }
         }
 
-        spline = tk::spline(xInputs, yInputs, getRequiredSplineType(numInputSamples));
+        spline = tk::spline(xInputs,
+                            yInputs,
+                            getRequiredSplineType(numInputSamples));
     }
 
     /**
      * @brief Implements Interpolator::interpolate()
      */
-    ValueType
-    interpolate(ValueType input, juce::Point<ValueType> /*leftPoint*/, juce::Point<ValueType> /*rightPoint*/) override
+    ValueType interpolate(ValueType input,
+                          juce::Point<ValueType> /*leftPoint*/,
+                          juce::Point<ValueType> /*rightPoint*/) override
     {
         return static_cast<ValueType>(spline(input));
     }
@@ -330,7 +352,8 @@ private:
     tk::spline::spline_type getRequiredSplineType(size_t numInputSamples) const
     {
         using spline_type = tk::spline::spline_type;
-        return (numInputSamples > 2) ? spline_type::cspline : spline_type::linear;
+        return (numInputSamples > 2) ? spline_type::cspline
+                                     : spline_type::linear;
     }
 
     // prepared state
@@ -355,7 +378,8 @@ public:
      *
      * @param[in]   identifier  Identifier for the interpolator
      */
-    static std::unique_ptr<Interpolator<ValueType>> makeInterpolator(const juce::Identifier& identifier)
+    static std::unique_ptr<Interpolator<ValueType>>
+    makeInterpolator(const juce::Identifier& identifier)
     {
         // TODO: this is probably fine for just 3 interpolator types, but could
         // be made more efficient / compact

--- a/src/Interpolator.h
+++ b/src/Interpolator.h
@@ -40,7 +40,8 @@
 namespace utility
 {
 
-//----------------------------------------------------------------------------------------------------------------- base
+//-----------------------------------------------------------------------------------------------------------------
+// base
 
 /**
  * @brief   Base class for interpolation algorithms
@@ -108,7 +109,8 @@ public:
     }
 
     /**
-     * @brief Invalidates the cache to cause values to be recomputed on next call to process
+     * @brief Invalidates the cache to cause values to be recomputed on next
+     * call to process
      */
     void invalidateCache()
     {
@@ -118,17 +120,20 @@ public:
 protected:
 
     /**
-     * @brief       Internal function implemented by derived classes to compute an interpolated value between two points
+     * @brief       Internal function implemented by derived classes to compute
+     * an interpolated value between two points
      *
      * @param[in]   input       Input to interpolate
      * @param[in]   leftPoint   Nearest point with x-coordinate to left of input
-     * @param[in]   rightPoint  Nearest point with x-coordinate to right of input
+     * @param[in]   rightPoint  Nearest point with x-coordinate to right of
+     * input
      */
     virtual ValueType interpolate(ValueType input, juce::Point<ValueType> leftPoint, juce::Point<ValueType> rightPoint)
         = 0;
 
     /**
-     * @brief       Internal function implemented by derived classes to prepare for calls to interpolate()
+     * @brief       Internal function implemented by derived classes to prepare
+     * for calls to interpolate()
      *
      * @param[in]   inputSamples    The input samples for interpolation
      */
@@ -153,8 +158,8 @@ protected:
     }
 
     /**
-     * @brief       Resets the sample cache and ensures enough output samples are allocated for the next round of
-     *              interpolation
+     * @brief       Resets the sample cache and ensures enough output samples
+     * are allocated for the next round of interpolation
      *
      * @param[in]   numSamples  Number of output samples required
      */
@@ -176,7 +181,8 @@ private:
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(Interpolator)
 };
 
-//--------------------------------------------------------------------------------------------------------------- linear
+//---------------------------------------------------------------------------------------------------------------
+// linear
 
 /**
  * @brief   Simple linear interpolator
@@ -215,12 +221,14 @@ public:
     inline static const juce::Identifier identifier = "Linear";
 };
 
-//--------------------------------------------------------------------------------------------------------------- cosine
+//---------------------------------------------------------------------------------------------------------------
+// cosine
 
 /**
  * @brief   Cosine interpolator
  *
- * @details Interpolates by drawing a half-cosine wave between each pair of points
+ * @details Interpolates by drawing a half-cosine wave between each pair of
+ * points
  */
 template <typename ValueType>
 class CosineInterpolator : public Interpolator<ValueType>
@@ -254,7 +262,8 @@ public:
     inline static const juce::Identifier identifier = "Cosine";
 };
 
-//--------------------------------------------------------------------------------------------------------------- spline
+//---------------------------------------------------------------------------------------------------------------
+// spline
 
 /**
  * @brief   Spline interpolator
@@ -310,10 +319,11 @@ public:
 private:
 
     /**
-     * @brief       Determine the required type of spline given the number of input samples
+     * @brief       Determine the required type of spline given the number of
+     * input samples
      *
-     * @details     Two points is not enough for a C2 spline, so in this case defaulting to linear is a sensible
-     *              alternative
+     * @details     Two points is not enough for a C2 spline, so in this case
+     * defaulting to linear is a sensible alternative
      *
      * @param[in]   numInputSamples     Number of input samples
      */
@@ -329,7 +339,8 @@ private:
     tk::spline spline;
 };
 
-//-------------------------------------------------------------------------------------------------------------- factory
+//--------------------------------------------------------------------------------------------------------------
+// factory
 
 /**
  * @brief Factory for creating interpolators from their identifiers
@@ -346,7 +357,8 @@ public:
      */
     static std::unique_ptr<Interpolator<ValueType>> makeInterpolator(const juce::Identifier& identifier)
     {
-        // TODO: this is probably fine for just 3 interpolator types, but could be made more efficient / compact
+        // TODO: this is probably fine for just 3 interpolator types, but could
+        // be made more efficient / compact
 
         if (identifier == LinearInterpolator<ValueType>::identifier)
         {

--- a/src/gui/appearance/LookAndFeel.cpp
+++ b/src/gui/appearance/LookAndFeel.cpp
@@ -24,8 +24,9 @@ LookAndFeel::LookAndFeel()
  */
 const juce::Typeface::Ptr LookAndFeel::getKarlaTypeface()
 {
-    static auto typeface
-        = juce::Typeface::createSystemTypefaceFor(BinaryData::KarlaLight_ttf, BinaryData::KarlaLight_ttfSize);
+    static auto typeface = juce::Typeface::createSystemTypefaceFor(
+        BinaryData::KarlaLight_ttf,
+        BinaryData::KarlaLight_ttfSize);
     return typeface;
 }
 
@@ -38,7 +39,8 @@ const juce::Typeface::Ptr LookAndFeel::getKarlaTypeface()
  *
  * @return  Equal width spacing for all tabs
  */
-int LookAndFeel::getTabButtonBestWidth(juce::TabBarButton& button, int /*tabDepth*/)
+int LookAndFeel::getTabButtonBestWidth(juce::TabBarButton& button,
+                                       int /*tabDepth*/)
 {
     float totalWidth = button.getTabbedButtonBar().getWidth();
     float numTabs = button.getTabbedButtonBar().getNumTabs();

--- a/src/gui/appearance/LookAndFeel.h
+++ b/src/gui/appearance/LookAndFeel.h
@@ -20,7 +20,8 @@ public:
 
     LookAndFeel();
 
-    int getTabButtonBestWidth(juce::TabBarButton& button, int tabDepth) override;
+    int getTabButtonBestWidth(juce::TabBarButton& button,
+                              int tabDepth) override;
 
 private:
 

--- a/src/gui/components/GraphComponent.h
+++ b/src/gui/components/GraphComponent.h
@@ -17,15 +17,17 @@
 namespace gui
 {
 
-using utility::Interpolator; // TODO: does this pollute the namespace when #include'ing this file?
+using utility::Interpolator; // TODO: does this pollute the namespace when
+                             // #include'ing this file?
 using utility::InterpolatorFactory;
 using utility::SplineInterpolator;
 
 /**
- * @brief   A graph drawing component which is optionally editable by mouse events
+ * @brief   A graph drawing component which is optionally editable by mouse
+ * events
  *
- * @details Currently supports only a graph in the positive x/y quadrant, but should easily be extendible to all four
- *          quadrants
+ * @details Currently supports only a graph in the positive x/y quadrant, but
+ * should easily be extendible to all four quadrants
  */
 template <typename ValueType>
 class GraphComponent : public juce::Component, public juce::KeyListener
@@ -119,7 +121,8 @@ GraphComponent<ValueType>::GraphComponent()
     setRangeX(0, 1);
     setRangeY(0, 1);
     setEditable(true);
-    setSize(100, 100); // need to start with non-zero size for point transformations
+    setSize(100,
+            100); // need to start with non-zero size for point transformations
     setWantsKeyboardFocus(true);
     setDrawsInterpolatedCurve(true);
 
@@ -238,9 +241,11 @@ void GraphComponent<ValueType>::setInterpolationMethod(const juce::Identifier& i
 }
 
 /**
- * @brief       Sets whether or not the interpolated curve should be calculated and drawn
+ * @brief       Sets whether or not the interpolated curve should be calculated
+ * and drawn
  *
- * @param[in]   shouldDrawInterpolatedCurve     Set true to draw interpolated curve
+ * @param[in]   shouldDrawInterpolatedCurve     Set true to draw interpolated
+ * curve
  */
 template <typename ValueType>
 void GraphComponent<ValueType>::setDrawsInterpolatedCurve(bool shouldDrawInterpolatedCurve)
@@ -268,10 +273,12 @@ void GraphComponent<ValueType>::paint(juce::Graphics& g)
 /**
  * @brief   Implements juce::Component::resized()
  *
- * @details This applies an affine transform to the interpolated path to resize it to the available bounds
+ * @details This applies an affine transform to the interpolated path to resize
+ * it to the available bounds
  *
- * @note    The component must start with a non-zero size, else the calls to resized() on app initialisation
- *          will result in an invalid (infinite) transform matrix which throws an exception when it is applied
+ * @note    The component must start with a non-zero size, else the calls to
+ * resized() on app initialisation will result in an invalid (infinite)
+ * transform matrix which throws an exception when it is applied
  */
 template <typename ValueType>
 void GraphComponent<ValueType>::resized()
@@ -301,7 +308,8 @@ void GraphComponent<ValueType>::mouseDown(const juce::MouseEvent& event)
             const auto newPoint = transformPointToGraph(event.getPosition());
             addPoint(newPoint);
 
-            // TODO: this effectively searches for the point that was just added, could be made more efficient
+            // TODO: this effectively searches for the point that was just
+            // added, could be made more efficient
             movingPointIndex = getPointNearMouseEvent(event);
         }
         // move
@@ -400,7 +408,8 @@ void GraphComponent<ValueType>::mouseUp(const juce::MouseEvent& /*event*/)
 /**
  * @brief   Implements juce::KeyListener::keyPressed()
  *
- * @details This is used to check for a 'delete' key press, toggling the delete point mode if the graph is editable
+ * @details This is used to check for a 'delete' key press, toggling the delete
+ * point mode if the graph is editable
  */
 template <typename ValueType>
 bool GraphComponent<ValueType>::keyPressed(const juce::KeyPress& key, juce::Component* /*originatingComponent*/)
@@ -595,7 +604,8 @@ void GraphComponent<ValueType>::paintCurve(juce::Graphics& g) const
 }
 
 /**
- * @brief       Transforms a graph point to the coordinates system used for painting
+ * @brief       Transforms a graph point to the coordinates system used for
+ * painting
  *
  * @param[in]
  * @param[in]   point   Point on the graph
@@ -617,7 +627,8 @@ juce::Point<int> GraphComponent<ValueType>::transformPointForPaint(const juce::R
 /**
  * @brief       Transforms a GUI point to the coordinates system of the graph
  *
- * @details     Use this in combination with mouse events to let the user add points to the graph
+ * @details     Use this in combination with mouse events to let the user add
+ * points to the graph
  *
  * @param[in]   point   The point to transform
  */
@@ -637,8 +648,8 @@ juce::Point<ValueType> GraphComponent<ValueType>::transformPointToGraph(const ju
 }
 
 /**
- * @brief       Checks if a mouse event is near a point on the graph, returning the index of the point if it does
- *              and -1 otherwise
+ * @brief       Checks if a mouse event is near a point on the graph, returning
+ * the index of the point if it does and -1 otherwise
  *
  * @param[in]   event   Mouse event
  *
@@ -664,13 +675,16 @@ int GraphComponent<ValueType>::getPointNearMouseEvent(const juce::MouseEvent& ev
 }
 
 /**
- * @brief       Checks if a point in the GUI is equivalent to a point on the graph
+ * @brief       Checks if a point in the GUI is equivalent to a point on the
+ * graph
  *
  * @param[in]   guiPoint        Point in the component's coordinate system
  * @param[in]   graphPoint      Point in the graph's coordinate system
  *
- * @return      true            The component point is equivalent to the graph point
- * @return      false           The component point is not equivalent to the graph point
+ * @return      true            The component point is equivalent to the graph
+ * point
+ * @return      false           The component point is not equivalent to the
+ * graph point
  */
 template <typename ValueType>
 bool GraphComponent<ValueType>::pointHitTest(const juce::Point<int>& guiPoint,

--- a/src/gui/components/GraphComponent.h
+++ b/src/gui/components/GraphComponent.h
@@ -59,7 +59,8 @@ public:
     void mouseDrag(const juce::MouseEvent& event) override;
     void mouseMove(const juce::MouseEvent& event) override;
     void mouseUp(const juce::MouseEvent& event) override;
-    bool keyPressed(const juce::KeyPress& key, juce::Component* originatingComponent) override;
+    bool keyPressed(const juce::KeyPress& key,
+                    juce::Component* originatingComponent) override;
     bool keyPressed(const juce::KeyPress& key) override;
 
 protected:
@@ -68,10 +69,13 @@ protected:
     juce::Array<juce::Point<ValueType>> points;
     juce::Path interpolatedPath;
 
-    juce::Point<int> transformPointForPaint(const juce::Rectangle<float>& bounds,
-                                            const juce::Point<ValueType>& point) const;
-    juce::Point<ValueType> transformPointToGraph(const juce::Point<int>& point) const;
-    bool pointHitTest(const juce::Point<int>& guiPoint, const juce::Point<ValueType>& graphPoint) const;
+    juce::Point<int>
+    transformPointForPaint(const juce::Rectangle<float>& bounds,
+                           const juce::Point<ValueType>& point) const;
+    juce::Point<ValueType>
+    transformPointToGraph(const juce::Point<int>& point) const;
+    bool pointHitTest(const juce::Point<int>& guiPoint,
+                      const juce::Point<ValueType>& graphPoint) const;
     int getPointNearMouseEvent(const juce::MouseEvent& event) const;
 
     void pointsChanged();
@@ -234,7 +238,8 @@ void GraphComponent<ValueType>::clear()
  * @param[in]   identifier     The new interpolator to use
  */
 template <typename ValueType>
-void GraphComponent<ValueType>::setInterpolationMethod(const juce::Identifier& identifier)
+void GraphComponent<ValueType>::setInterpolationMethod(
+    const juce::Identifier& identifier)
 {
     interpolator = InterpolatorFactory<ValueType>::makeInterpolator(identifier);
     jassert(interpolator);
@@ -248,7 +253,8 @@ void GraphComponent<ValueType>::setInterpolationMethod(const juce::Identifier& i
  * curve
  */
 template <typename ValueType>
-void GraphComponent<ValueType>::setDrawsInterpolatedCurve(bool shouldDrawInterpolatedCurve)
+void GraphComponent<ValueType>::setDrawsInterpolatedCurve(
+    bool shouldDrawInterpolatedCurve)
 {
     shouldInterpolate = shouldDrawInterpolatedCurve;
 }
@@ -300,7 +306,8 @@ void GraphComponent<ValueType>::mouseDown(const juce::MouseEvent& event)
     int pointIndex = getPointNearMouseEvent(event);
 
     // check if should create new or move
-    if (pointEditState == PointEditingState::None || pointEditState == PointEditingState::OverPoint)
+    if (pointEditState == PointEditingState::None
+        || pointEditState == PointEditingState::OverPoint)
     {
         // create new
         if (pointIndex == -1)
@@ -351,13 +358,15 @@ void GraphComponent<ValueType>::mouseDrag(const juce::MouseEvent& event)
 
         // check if point has moved past the x-coordinate of another point
         // swap them if this is the case
-        if (movingPointIndex != 0 && points[movingPointIndex - 1].getX() > point.getX())
+        if (movingPointIndex != 0
+            && points[movingPointIndex - 1].getX() > point.getX())
         {
             points.swap(movingPointIndex, movingPointIndex - 1);
             movingPointIndex = movingPointIndex - 1;
         }
         else if (movingPointIndex != points.size() - 1
-                 && points[movingPointIndex].getX() > points[movingPointIndex + 1].getX())
+                 && points[movingPointIndex].getX()
+                        > points[movingPointIndex + 1].getX())
         {
             points.swap(movingPointIndex, movingPointIndex + 1);
             movingPointIndex = movingPointIndex + 1;
@@ -412,12 +421,15 @@ void GraphComponent<ValueType>::mouseUp(const juce::MouseEvent& /*event*/)
  * point mode if the graph is editable
  */
 template <typename ValueType>
-bool GraphComponent<ValueType>::keyPressed(const juce::KeyPress& key, juce::Component* /*originatingComponent*/)
+bool GraphComponent<ValueType>::keyPressed(
+    const juce::KeyPress& key,
+    juce::Component* /*originatingComponent*/)
 {
     if (editable && key.isKeyCode(juce::KeyPress::backspaceKey))
     {
-        pointEditState
-            = (pointEditState == PointEditingState::Delete) ? PointEditingState::None : PointEditingState::Delete;
+        pointEditState = (pointEditState == PointEditingState::Delete)
+                             ? PointEditingState::None
+                             : PointEditingState::Delete;
 
         updateCursor();
         return true;
@@ -446,11 +458,12 @@ void GraphComponent<ValueType>::updateCursor()
     switch (pointEditState)
     {
     case PointEditingState::Delete:
-        setMouseCursor(
-            juce::MouseCursor(juce::ImageCache::getFromMemory(BinaryData::Delete_png, BinaryData::Delete_pngSize),
-                              1,
-                              7,
-                              5));
+        setMouseCursor(juce::MouseCursor(
+            juce::ImageCache::getFromMemory(BinaryData::Delete_png,
+                                            BinaryData::Delete_pngSize),
+            1,
+            7,
+            5));
         break;
 
     case PointEditingState::Move:
@@ -507,7 +520,8 @@ void GraphComponent<ValueType>::recalculateInterpolatedPath()
 
     if (points.size() > 1)
     {
-        auto start = transformPointForPaint(bounds, points.getFirst()).toFloat();
+        auto start
+            = transformPointForPaint(bounds, points.getFirst()).toFloat();
         interpolatedPath.startNewSubPath(start.getX(), start.getY());
 
         interpolator->process(points, 500);
@@ -579,8 +593,10 @@ void GraphComponent<ValueType>::paintPoints(juce::Graphics& g) const
     {
         auto transformedPoint = transformPointForPaint(bounds, point).toFloat();
 
-        const auto x = static_cast<float>(transformedPoint.getX() - circleShift);
-        const auto y = static_cast<float>(transformedPoint.getY() - circleShift);
+        const auto x
+            = static_cast<float>(transformedPoint.getX() - circleShift);
+        const auto y
+            = static_cast<float>(transformedPoint.getY() - circleShift);
 
         g.drawEllipse(x, y, circleSize, circleSize, circleSize);
     }
@@ -611,11 +627,14 @@ void GraphComponent<ValueType>::paintCurve(juce::Graphics& g) const
  * @param[in]   point   Point on the graph
  */
 template <typename ValueType>
-juce::Point<int> GraphComponent<ValueType>::transformPointForPaint(const juce::Rectangle<float>& bounds,
-                                                                   const juce::Point<ValueType>& point) const
+juce::Point<int> GraphComponent<ValueType>::transformPointForPaint(
+    const juce::Rectangle<float>& bounds,
+    const juce::Point<ValueType>& point) const
 {
-    const float xScale = bounds.getWidth() / static_cast<float>(valueBounds.getWidth());
-    const float yScale = bounds.getHeight() / static_cast<float>(valueBounds.getHeight());
+    const float xScale
+        = bounds.getWidth() / static_cast<float>(valueBounds.getWidth());
+    const float yScale
+        = bounds.getHeight() / static_cast<float>(valueBounds.getHeight());
     const auto fPoint = point.toFloat();
 
     auto x = static_cast<int>(fPoint.getX() * xScale);
@@ -633,7 +652,8 @@ juce::Point<int> GraphComponent<ValueType>::transformPointForPaint(const juce::R
  * @param[in]   point   The point to transform
  */
 template <typename ValueType>
-juce::Point<ValueType> GraphComponent<ValueType>::transformPointToGraph(const juce::Point<int>& point) const
+juce::Point<ValueType> GraphComponent<ValueType>::transformPointToGraph(
+    const juce::Point<int>& point) const
 {
     const auto xScale = static_cast<double>(getMaxX()) / getWidth();
     const auto yScale = static_cast<double>(getMaxY()) / getHeight();
@@ -657,7 +677,8 @@ juce::Point<ValueType> GraphComponent<ValueType>::transformPointToGraph(const ju
  * @return      >0      Mouse event is near the point with the returned index
  */
 template <typename ValueType>
-int GraphComponent<ValueType>::getPointNearMouseEvent(const juce::MouseEvent& event) const
+int GraphComponent<ValueType>::getPointNearMouseEvent(
+    const juce::MouseEvent& event) const
 {
     const auto eventPosition = event.getPosition().toInt();
 
@@ -687,12 +708,14 @@ int GraphComponent<ValueType>::getPointNearMouseEvent(const juce::MouseEvent& ev
  * graph point
  */
 template <typename ValueType>
-bool GraphComponent<ValueType>::pointHitTest(const juce::Point<int>& guiPoint,
-                                             const juce::Point<ValueType>& graphPoint) const
+bool GraphComponent<ValueType>::pointHitTest(
+    const juce::Point<int>& guiPoint,
+    const juce::Point<ValueType>& graphPoint) const
 {
     const int clickRadius = 10;
 
-    auto transformedPoint = transformPointForPaint(getLocalBounds().toFloat(), graphPoint);
+    auto transformedPoint
+        = transformPointForPaint(getLocalBounds().toFloat(), graphPoint);
     int distance = transformedPoint.getDistanceFrom(guiPoint);
 
     return distance < clickRadius;

--- a/src/gui/components/InverterConfigComponent.cpp
+++ b/src/gui/components/InverterConfigComponent.cpp
@@ -11,8 +11,10 @@ namespace gui
 /**
  * @brief   Constructor
  */
-InverterConfigComponent::InverterConfigComponent(std::shared_ptr<ConfigurationValueTree> sharedConfigValueTree)
-    : configValueTree(sharedConfigValueTree), torqueMapComponent(sharedConfigValueTree)
+InverterConfigComponent::InverterConfigComponent(
+    std::shared_ptr<ConfigurationValueTree> sharedConfigValueTree)
+    : configValueTree(sharedConfigValueTree),
+      torqueMapComponent(sharedConfigValueTree)
 {
     setupInterpolationCombo();
 
@@ -25,10 +27,13 @@ InverterConfigComponent::InverterConfigComponent(std::shared_ptr<ConfigurationVa
  */
 void InverterConfigComponent::setupInterpolationCombo()
 {
-    const auto& interpolationMethods = utility::InterpolatorFactory<int>::getAllIdentifiers();
+    const auto& interpolationMethods
+        = utility::InterpolatorFactory<int>::getAllIdentifiers();
 
-    juce::ValueTree torqueMap = configValueTree->getChildWithName(ConfigurationValueTree::Children::TorqueMap);
-    const juce::String selectedMethod = torqueMap.getProperty(ConfigurationValueTree::Properties::InterpolationMethod);
+    juce::ValueTree torqueMap = configValueTree->getChildWithName(
+        ConfigurationValueTree::Children::TorqueMap);
+    const juce::String selectedMethod = torqueMap.getProperty(
+        ConfigurationValueTree::Properties::InterpolationMethod);
 
     for (unsigned i = 0; i < interpolationMethods.size(); i++)
     {
@@ -47,9 +52,12 @@ void InverterConfigComponent::setupInterpolationCombo()
     {
         int selectedIndex = interpolationCombo.getSelectedItemIndex();
         juce::String value = interpolationCombo.getItemText(selectedIndex);
-        auto map = configValueTree->getChildWithName(ConfigurationValueTree::Children::TorqueMap);
+        auto map = configValueTree->getChildWithName(
+            ConfigurationValueTree::Children::TorqueMap);
 
-        map.setProperty(ConfigurationValueTree::Properties::InterpolationMethod, value, nullptr);
+        map.setProperty(ConfigurationValueTree::Properties::InterpolationMethod,
+                        value,
+                        nullptr);
     };
 }
 

--- a/src/gui/components/InverterConfigComponent.h
+++ b/src/gui/components/InverterConfigComponent.h
@@ -20,7 +20,8 @@ class InverterConfigComponent : public juce::Component
 {
 public:
 
-    InverterConfigComponent(std::shared_ptr<ConfigurationValueTree> sharedConfigValueTree);
+    InverterConfigComponent(
+        std::shared_ptr<ConfigurationValueTree> sharedConfigValueTree);
 
     void setupInterpolationCombo();
 

--- a/src/gui/components/MainComponent.cpp
+++ b/src/gui/components/MainComponent.cpp
@@ -118,11 +118,13 @@ void MainComponent::valueTreeRedirected(juce::ValueTree& redirectedTree)
 {
     // if (redirectedTree == configValueTree->getRoot())
     // {
-    //     auto torqueMap = configValueTree->getChildWithName(ConfigurationValueTree::Children::TorqueMap);
+    //     auto torqueMap =
+    //     configValueTree->getChildWithName(ConfigurationValueTree::Children::TorqueMap);
 
-    //     // TODO: this should be replaced by something (1) faster (2) that is its own function!
-    //     juce::String interpolationMethod
-    //         = torqueMap.getProperty(ConfigurationValueTree::Properties::InterpolationMethod);
+    //     // TODO: this should be replaced by something (1) faster (2) that is
+    //     its own function! juce::String interpolationMethod
+    //         =
+    //         torqueMap.getProperty(ConfigurationValueTree::Properties::InterpolationMethod);
 
     //     for (int i = 0; i < interpolationCombo.getNumItems(); i++)
     //     {

--- a/src/gui/components/MainComponent.cpp
+++ b/src/gui/components/MainComponent.cpp
@@ -15,15 +15,20 @@ namespace gui
 /**
  * @brief Default constructor
  */
-MainComponent::MainComponent(std::shared_ptr<ConfigurationValueTree> sharedConfigValueTree)
-    : configValueTree(sharedConfigValueTree), inverterComponent(sharedConfigValueTree)
+MainComponent::MainComponent(
+    std::shared_ptr<ConfigurationValueTree> sharedConfigValueTree)
+    : configValueTree(sharedConfigValueTree),
+      inverterComponent(sharedConfigValueTree)
 {
     setSize(600, 400);
 
     configValueTree->addListener(this);
 
     auto& lf = getLookAndFeel();
-    tabComponent.addTab("Inverter", lf.findColour(juce::DocumentWindow::backgroundColourId), &inverterComponent, false);
+    tabComponent.addTab("Inverter",
+                        lf.findColour(juce::DocumentWindow::backgroundColourId),
+                        &inverterComponent,
+                        false);
     addAndMakeVisible(tabComponent);
 }
 
@@ -43,7 +48,8 @@ MainComponent::~MainComponent()
 void MainComponent::paint(juce::Graphics& g)
 {
     auto& lf = getLookAndFeel();
-    auto backgroundColour = lf.findColour(juce::ResizableWindow::backgroundColourId);
+    auto backgroundColour
+        = lf.findColour(juce::ResizableWindow::backgroundColourId);
 
     if (fileIsBeingDragged)
     {
@@ -82,7 +88,9 @@ bool MainComponent::isInterestedInFileDrag(const juce::StringArray& files)
 /**
  * @brief   Implements juce::FileDragAndDropTarget::filesDropped()
  */
-void MainComponent::filesDropped(const juce::StringArray& files, int /*x*/, int /*y*/)
+void MainComponent::filesDropped(const juce::StringArray& files,
+                                 int /*x*/,
+                                 int /*y*/)
 {
     const auto& fileName = files[0];
     jassert(fileName.endsWithIgnoreCase(".xml"));
@@ -96,7 +104,9 @@ void MainComponent::filesDropped(const juce::StringArray& files, int /*x*/, int 
 /**
  * @brief   Implements juce::FileDragAndDropTarget::fileDragEnter()
  */
-void MainComponent::fileDragEnter(const juce::StringArray& /*files*/, int /*x*/, int /*y*/)
+void MainComponent::fileDragEnter(const juce::StringArray& /*files*/,
+                                  int /*x*/,
+                                  int /*y*/)
 {
     fileIsBeingDragged = true;
     repaint();

--- a/src/gui/components/MainComponent.h
+++ b/src/gui/components/MainComponent.h
@@ -17,12 +17,15 @@ namespace gui
 /**
  * @brief Main GUI component
  */
-class MainComponent : public juce::Component, public juce::FileDragAndDropTarget, public juce::ValueTree::Listener
+class MainComponent : public juce::Component,
+                      public juce::FileDragAndDropTarget,
+                      public juce::ValueTree::Listener
 {
 public:
 
     // constructor / destructor
-    MainComponent(std::shared_ptr<ConfigurationValueTree> sharedConfigValueTree);
+    MainComponent(
+        std::shared_ptr<ConfigurationValueTree> sharedConfigValueTree);
     ~MainComponent() override;
 
     // graphics

--- a/src/gui/components/TabbedComponent.cpp
+++ b/src/gui/components/TabbedComponent.cpp
@@ -11,7 +11,8 @@ namespace gui
 /**
  * @brief   Constructor
  */
-TabbedComponent::TabbedComponent() : juce::TabbedComponent(juce::TabbedButtonBar::Orientation::TabsAtTop)
+TabbedComponent::TabbedComponent()
+    : juce::TabbedComponent(juce::TabbedButtonBar::Orientation::TabsAtTop)
 {
 }
 

--- a/src/gui/components/TorqueMapComponent.cpp
+++ b/src/gui/components/TorqueMapComponent.cpp
@@ -63,7 +63,8 @@ void TorqueMapComponent::loadTorqueMapData()
  */
 void TorqueMapComponent::syncTorqueMapData()
 {
-    // TODO: this function isn't called that often, but rewriting the entire set of points is not a very efficient way
+    // TODO: this function isn't called that often, but rewriting the entire set
+    // of points is not a very efficient way
     //       to update the tree
     auto torqueMap = configValueTree->getChildWithName(ConfigurationValueTree::Children::TorqueMap);
     torqueMap.removeAllChildren(nullptr);
@@ -112,7 +113,8 @@ void TorqueMapComponent::paintDeadzoneOverlay(juce::Graphics& g) const
 /**
  * @brief   Overrides GraphComponent::mouseDown()
  *
- * @details Mouse events are intercepted if in the deadzone and forwarded otherwise
+ * @details Mouse events are intercepted if in the deadzone and forwarded
+ * otherwise
  */
 void TorqueMapComponent::mouseDown(const juce::MouseEvent& event)
 {
@@ -132,7 +134,8 @@ void TorqueMapComponent::mouseDown(const juce::MouseEvent& event)
 /**
  * @brief   Overrides GraphComponent::mouseUp()
  *
- * @details Mouse events are intercepted if in the deadzone and forwarded otherwise
+ * @details Mouse events are intercepted if in the deadzone and forwarded
+ * otherwise
  */
 void TorqueMapComponent::mouseUp(const juce::MouseEvent& event)
 {
@@ -150,7 +153,8 @@ void TorqueMapComponent::mouseUp(const juce::MouseEvent& event)
 /**
  * @brief   Overrides GraphComponent::mouseDrag()
  *
- * @details Mouse events are intercepted if in the deadzone and forwarded otherwise
+ * @details Mouse events are intercepted if in the deadzone and forwarded
+ * otherwise
  */
 void TorqueMapComponent::mouseDrag(const juce::MouseEvent& event)
 {
@@ -181,7 +185,8 @@ void TorqueMapComponent::mouseDrag(const juce::MouseEvent& event)
 /**
  * @brief   Overrides GraphComponent::mouseMove()
  *
- * @details Mouse events are intercepted if in the deadzone and forwarded otherwise
+ * @details Mouse events are intercepted if in the deadzone and forwarded
+ * otherwise
  */
 void TorqueMapComponent::mouseMove(const juce::MouseEvent& event)
 {
@@ -210,7 +215,8 @@ bool TorqueMapComponent::mouseEventInDeadzone(const juce::MouseEvent& event) con
 }
 
 /**
- * @brief       Checks if the mouse event is near a point which should not be edited
+ * @brief       Checks if the mouse event is near a point which should not be
+ * edited
  *
  * @details     The first and last points should not be edited
  *

--- a/src/gui/components/TorqueMapComponent.cpp
+++ b/src/gui/components/TorqueMapComponent.cpp
@@ -15,7 +15,8 @@ namespace gui
 /**
  * @brief Constructor
  */
-TorqueMapComponent::TorqueMapComponent(std::shared_ptr<ConfigurationValueTree> sharedConfigValueTree)
+TorqueMapComponent::TorqueMapComponent(
+    std::shared_ptr<ConfigurationValueTree> sharedConfigValueTree)
     : configValueTree(sharedConfigValueTree)
 {
     configValueTree->addListener(this);
@@ -32,9 +33,14 @@ TorqueMapComponent::TorqueMapComponent(std::shared_ptr<ConfigurationValueTree> s
 void TorqueMapComponent::loadTorqueMapData()
 {
     // interpolation method
-    auto torqueMap = configValueTree->getChildWithName(ConfigurationValueTree::Children::TorqueMap);
+    auto torqueMap = configValueTree->getChildWithName(
+        ConfigurationValueTree::Children::TorqueMap);
 
-    setInterpolationMethod(torqueMap.getProperty(ConfigurationValueTree::Properties::InterpolationMethod).toString());
+    setInterpolationMethod(
+        torqueMap
+            .getProperty(
+                ConfigurationValueTree::Properties::InterpolationMethod)
+            .toString());
 
     // data points
     clear();
@@ -47,8 +53,10 @@ void TorqueMapComponent::loadTorqueMapData()
 
         if (child.hasType(ConfigurationValueTree::Children::TorqueMapPoint))
         {
-            int input = child.getProperty(ConfigurationValueTree::Properties::InputValue);
-            int output = child.getProperty(ConfigurationValueTree::Properties::OutputValue);
+            int input = child.getProperty(
+                ConfigurationValueTree::Properties::InputValue);
+            int output = child.getProperty(
+                ConfigurationValueTree::Properties::OutputValue);
 
             addPoint({input, output});
         }
@@ -66,12 +74,17 @@ void TorqueMapComponent::syncTorqueMapData()
     // TODO: this function isn't called that often, but rewriting the entire set
     // of points is not a very efficient way
     //       to update the tree
-    auto torqueMap = configValueTree->getChildWithName(ConfigurationValueTree::Children::TorqueMap);
+    auto torqueMap = configValueTree->getChildWithName(
+        ConfigurationValueTree::Children::TorqueMap);
     torqueMap.removeAllChildren(nullptr);
 
     for (const auto& point : points)
     {
-        torqueMap.addChild(ConfigurationValueTree::createTorqueMapPoint(point.getX(), point.getY()), -1, nullptr);
+        torqueMap.addChild(
+            ConfigurationValueTree::createTorqueMapPoint(point.getX(),
+                                                         point.getY()),
+            -1,
+            nullptr);
     }
 }
 
@@ -90,7 +103,9 @@ void TorqueMapComponent::paint(juce::Graphics& g)
  */
 juce::Rectangle<int> TorqueMapComponent::getDeadzoneBounds() const
 {
-    auto deadzoneEdgePoint = transformPointForPaint(getLocalBounds().toFloat(), {deadzonePosition, getHeight()});
+    auto deadzoneEdgePoint
+        = transformPointForPaint(getLocalBounds().toFloat(),
+                                 {deadzonePosition, getHeight()});
     return juce::Rectangle<int>({0, 0}, deadzoneEdgePoint);
 }
 
@@ -107,7 +122,9 @@ void TorqueMapComponent::paintDeadzoneOverlay(juce::Graphics& g) const
     g.fillRect(deadzoneBounds.expanded(0, 5));
 
     g.setColour(deadzoneColour);
-    g.drawVerticalLine(deadzoneBounds.getWidth(), 0, deadzoneBounds.toFloat().getHeight());
+    g.drawVerticalLine(deadzoneBounds.getWidth(),
+                       0,
+                       deadzoneBounds.toFloat().getHeight());
 }
 
 /**
@@ -164,10 +181,14 @@ void TorqueMapComponent::mouseDrag(const juce::MouseEvent& event)
         {
             jassert(points.size() >= 2);
 
-            auto newDeadzonePosition = transformPointToGraph(event.getPosition()).getX();
-            auto maxDeadzonePosition = points[1].getX(); // don't allow deadzone to pass 2nd graph point
+            auto newDeadzonePosition
+                = transformPointToGraph(event.getPosition()).getX();
+            auto maxDeadzonePosition
+                = points[1]
+                      .getX(); // don't allow deadzone to pass 2nd graph point
 
-            deadzonePosition = utility::clip(newDeadzonePosition, 0, maxDeadzonePosition);
+            deadzonePosition
+                = utility::clip(newDeadzonePosition, 0, maxDeadzonePosition);
             points.getReference(0).setX(deadzonePosition);
 
             pointsChanged();
@@ -207,7 +228,8 @@ void TorqueMapComponent::mouseMove(const juce::MouseEvent& event)
  *
  * @param[in]   event   The mouse event
  */
-bool TorqueMapComponent::mouseEventInDeadzone(const juce::MouseEvent& event) const
+bool TorqueMapComponent::mouseEventInDeadzone(
+    const juce::MouseEvent& event) const
 {
     const int deadzoneEdgeOffset = 2;
     auto point = transformPointToGraph(event.getPosition());
@@ -222,7 +244,8 @@ bool TorqueMapComponent::mouseEventInDeadzone(const juce::MouseEvent& event) con
  *
  * @param[in]   event   The mouse event
  */
-bool TorqueMapComponent::shouldPreventPointEdit(const juce::MouseEvent& event) const
+bool TorqueMapComponent::shouldPreventPointEdit(
+    const juce::MouseEvent& event) const
 {
     return (pointHitTest(event.getPosition(), points.getFirst())
             || pointHitTest(event.getPosition(), points.getLast()));
@@ -238,13 +261,17 @@ void TorqueMapComponent::showDeadzoneTooltip()
         deadzoneTooltip = std::make_unique<juce::TooltipWindow>(this, 0);
     }
 
-    auto deadzoneX = transformPointForPaint(getLocalBounds().toFloat(), {deadzonePosition, 0}).getX();
+    auto deadzoneX = transformPointForPaint(getLocalBounds().toFloat(),
+                                            {deadzonePosition, 0})
+                         .getX();
 
     int tipX = this->getScreenX() + deadzoneX - 10;
     int tipY = juce::Desktop::getMousePosition().getY();
 
     juce::String tipText
-        = juce::String::toDecimalStringWithSignificantFigures(100 * static_cast<float>(deadzonePosition) / inputMax, 2)
+        = juce::String::toDecimalStringWithSignificantFigures(
+              100 * static_cast<float>(deadzonePosition) / inputMax,
+              2)
           + "%";
 
     deadzoneTooltip->displayTip({tipX, tipY}, tipText);
@@ -262,7 +289,8 @@ void TorqueMapComponent::hideDeadzoneTooltip()
 /**
  * @brief Implements juce::ValueTree::Listener::valueTreeRedirected()
  */
-void TorqueMapComponent::valueTreeRedirected(juce::ValueTree& /*redirectedTree*/)
+void TorqueMapComponent::valueTreeRedirected(
+    juce::ValueTree& /*redirectedTree*/)
 {
     loadTorqueMapData();
 }
@@ -270,16 +298,22 @@ void TorqueMapComponent::valueTreeRedirected(juce::ValueTree& /*redirectedTree*/
 /**
  * @brief Implements juce::ValueTree::Listener::valueTreePropertyChanged()
  */
-void TorqueMapComponent::valueTreePropertyChanged(juce::ValueTree& changedTree, const juce::Identifier& property)
+void TorqueMapComponent::valueTreePropertyChanged(
+    juce::ValueTree& changedTree,
+    const juce::Identifier& property)
 {
-    auto torqueMap = configValueTree->getChildWithName(ConfigurationValueTree::Children::TorqueMap);
+    auto torqueMap = configValueTree->getChildWithName(
+        ConfigurationValueTree::Children::TorqueMap);
 
     if (changedTree == torqueMap)
     {
         if (property == ConfigurationValueTree::Properties::InterpolationMethod)
         {
             setInterpolationMethod(
-                torqueMap.getProperty(ConfigurationValueTree::Properties::InterpolationMethod).toString());
+                torqueMap
+                    .getProperty(
+                        ConfigurationValueTree::Properties::InterpolationMethod)
+                    .toString());
             repaint();
         }
     }

--- a/src/gui/components/TorqueMapComponent.h
+++ b/src/gui/components/TorqueMapComponent.h
@@ -19,7 +19,8 @@ class TorqueMapComponent : public GraphComponent<int>, juce::ValueTree::Listener
 {
 public:
 
-    TorqueMapComponent(std::shared_ptr<ConfigurationValueTree> sharedConfigValueTree);
+    TorqueMapComponent(
+        std::shared_ptr<ConfigurationValueTree> sharedConfigValueTree);
 
     void paint(juce::Graphics& g) override;
 
@@ -30,7 +31,8 @@ public:
     void mouseMove(const juce::MouseEvent& event) override;
 
     // configuration change handlers
-    void valueTreePropertyChanged(juce::ValueTree& changedTree, const juce::Identifier& property) override;
+    void valueTreePropertyChanged(juce::ValueTree& changedTree,
+                                  const juce::Identifier& property) override;
     void valueTreeRedirected(juce::ValueTree& redirectedTree) override;
 
 private:

--- a/src/gui/menubar/MenuBar.cpp
+++ b/src/gui/menubar/MenuBar.cpp
@@ -12,7 +12,8 @@ namespace gui
 /**
  * @brief Constructor
  */
-MenuBar::MenuBar(std::shared_ptr<CommandManager> sharedCommandManager) : commandManager(sharedCommandManager)
+MenuBar::MenuBar(std::shared_ptr<CommandManager> sharedCommandManager)
+    : commandManager(sharedCommandManager)
 {
     jassert(commandManager);
     commandManager->registerAllCommandsForTarget(this);
@@ -40,7 +41,8 @@ MenuBar::~MenuBar()
  */
 void MenuBar::createMainMenu()
 {
-    mainMenu.addCommandItem(commandManager.get(), CommandManager::CommandIDs::ShowAboutWindow);
+    mainMenu.addCommandItem(commandManager.get(),
+                            CommandManager::CommandIDs::ShowAboutWindow);
 }
 
 #if JUCE_MAC
@@ -117,7 +119,8 @@ juce::StringArray MenuBar::getMenuBarNames()
 /**
  * Implements juce::MenuBarModel::getMenuForIndex()
  */
-juce::PopupMenu MenuBar::getMenuForIndex(int topLevelMenuIndex, const juce::String& menuName)
+juce::PopupMenu MenuBar::getMenuForIndex(int topLevelMenuIndex,
+                                         const juce::String& menuName)
 {
     (void) menuName;
 
@@ -165,7 +168,8 @@ void MenuBar::getAllCommands(juce::Array<juce::CommandID>& commands)
 /**
  * Implements juce::ApplicationCommandTarget::getCommandInfo()
  */
-void MenuBar::getCommandInfo(juce::CommandID commandID, juce::ApplicationCommandInfo& result)
+void MenuBar::getCommandInfo(juce::CommandID commandID,
+                             juce::ApplicationCommandInfo& result)
 {
     switch (commandID)
     {
@@ -196,7 +200,8 @@ bool MenuBar::perform(const InvocationInfo& info)
         {
             aboutWindow = std::make_unique<AboutWindow>(commandManager);
 
-            aboutWindow->onCloseButtonPressed = [this]() { aboutWindow.reset(); };
+            aboutWindow->onCloseButtonPressed
+                = [this]() { aboutWindow.reset(); };
         }
         break;
     }

--- a/src/gui/menubar/MenuBar.h
+++ b/src/gui/menubar/MenuBar.h
@@ -26,13 +26,15 @@ public:
     ~MenuBar() override;
 
     juce::StringArray getMenuBarNames() override;
-    juce::PopupMenu getMenuForIndex(int topLevelMenuIndex, const juce::String& menuName) override;
+    juce::PopupMenu getMenuForIndex(int topLevelMenuIndex,
+                                    const juce::String& menuName) override;
     void menuItemSelected(int menuItemID, int topLevelMenuIndex) override;
     void menuBarActivated(bool isActive) override;
 
     void getAllCommands(juce::Array<juce::CommandID>& commands) override;
     juce::ApplicationCommandTarget* getNextCommandTarget() override;
-    void getCommandInfo(juce::CommandID commandID, juce::ApplicationCommandInfo& result) override;
+    void getCommandInfo(juce::CommandID commandID,
+                        juce::ApplicationCommandInfo& result) override;
     bool perform(const InvocationInfo& info) override;
 
 private:

--- a/src/gui/utility/PointComparator.h
+++ b/src/gui/utility/PointComparator.h
@@ -27,7 +27,8 @@ public:
      * @param[in]   p1      First point
      * @param[in]   p2      Second point
      */
-    static int compareElements(const juce::Point<ValueType>& p1, const juce::Point<ValueType>& p2)
+    static int compareElements(const juce::Point<ValueType>& p1,
+                               const juce::Point<ValueType>& p2)
     {
         if (p1.getX() < p2.getX())
         {

--- a/src/gui/windows/AboutWindow.cpp
+++ b/src/gui/windows/AboutWindow.cpp
@@ -13,7 +13,8 @@ namespace gui
  * @brief Constructor
  */
 AboutWindow::AboutWindow(std::shared_ptr<CommandManager> sharedCommandManager)
-    : juce::DialogWindow("About", juce::Colours::white, true), commandManager(sharedCommandManager)
+    : juce::DialogWindow("About", juce::Colours::white, true),
+      commandManager(sharedCommandManager)
 {
     setUsingNativeTitleBar(true);
     setResizable(false, false);
@@ -61,14 +62,19 @@ void AboutWindow::getAllCommands(juce::Array<juce::CommandID>& commands)
 /**
  * @brief Implements juce::ApplicationCommandTarget::getCommandInfo()
  */
-void AboutWindow::getCommandInfo(juce::CommandID commandID, juce::ApplicationCommandInfo& result)
+void AboutWindow::getCommandInfo(juce::CommandID commandID,
+                                 juce::ApplicationCommandInfo& result)
 {
     switch (commandID)
     {
     case CommandManager::CloseWindow:
     {
-        result.setInfo(juce::String("Close"), "Closes the window", CommandManager::CommandCategories::GUI, 0);
-        result.defaultKeypresses.add(juce::KeyPress('w', juce::ModifierKeys::commandModifier, 0));
+        result.setInfo(juce::String("Close"),
+                       "Closes the window",
+                       CommandManager::CommandCategories::GUI,
+                       0);
+        result.defaultKeypresses.add(
+            juce::KeyPress('w', juce::ModifierKeys::commandModifier, 0));
         break;
     }
 
@@ -113,7 +119,8 @@ AboutWindow::AboutComponent::AboutComponent()
     setupLabels();
 
     appIconImage.setImage(
-        juce::ImageCache::getFromMemory(BinaryData::AppIcon_1024_png, BinaryData::AppIcon_1024_pngSize));
+        juce::ImageCache::getFromMemory(BinaryData::AppIcon_1024_png,
+                                        BinaryData::AppIcon_1024_pngSize));
 
     addAndMakeVisible(appIconImage);
 }
@@ -123,25 +130,31 @@ AboutWindow::AboutComponent::AboutComponent()
  */
 void AboutWindow::AboutComponent::setupLabels()
 {
-    using Initialiser = std::tuple<juce::Label*, const juce::String, float, juce::Justification, juce::Colour>;
+    using Initialiser = std::tuple<juce::Label*,
+                                   const juce::String,
+                                   float,
+                                   juce::Justification,
+                                   juce::Colour>;
 
-    const std::initializer_list<Initialiser> initList = {{&appNameLabel,
-                                                          juce::String(ProjectInfo::projectName),
-                                                          50,
-                                                          juce::Justification::bottomLeft,
-                                                          juce::Colour(225, 225, 225)},
-                                                         {&versionLabel,
-                                                          juce::String("Version ") + ProjectInfo::versionString,
-                                                          18,
-                                                          juce::Justification::topLeft,
-                                                          juce::Colour(180, 180, 180)},
-                                                         {&commitHashLabel,
-                                                          juce::String(GIT_COMMIT_HASH),
-                                                          10,
-                                                          juce::Justification::centredLeft,
-                                                          juce::Colour(120, 120, 120)}};
+    const std::initializer_list<Initialiser> initList
+        = {{&appNameLabel,
+            juce::String(ProjectInfo::projectName),
+            50,
+            juce::Justification::bottomLeft,
+            juce::Colour(225, 225, 225)},
+           {&versionLabel,
+            juce::String("Version ") + ProjectInfo::versionString,
+            18,
+            juce::Justification::topLeft,
+            juce::Colour(180, 180, 180)},
+           {&commitHashLabel,
+            juce::String(GIT_COMMIT_HASH),
+            10,
+            juce::Justification::centredLeft,
+            juce::Colour(120, 120, 120)}};
 
-    for (const auto& [component, text, fontHeight, justification, textColour] : initList)
+    for (const auto& [component, text, fontHeight, justification, textColour] :
+         initList)
     {
         addAndMakeVisible(*component);
         component->setText(text, juce::dontSendNotification);

--- a/src/gui/windows/AboutWindow.h
+++ b/src/gui/windows/AboutWindow.h
@@ -18,7 +18,8 @@ namespace gui
  * @brief 'About' window
  */
 
-class AboutWindow : public juce::DialogWindow, public juce::ApplicationCommandTarget
+class AboutWindow : public juce::DialogWindow,
+                    public juce::ApplicationCommandTarget
 {
 public:
 
@@ -29,7 +30,8 @@ public:
 
     // command handling
     void getAllCommands(juce::Array<juce::CommandID>& commands) override;
-    void getCommandInfo(juce::CommandID commandID, juce::ApplicationCommandInfo& result) override;
+    void getCommandInfo(juce::CommandID commandID,
+                        juce::ApplicationCommandInfo& result) override;
     bool perform(const InvocationInfo& info) override;
     juce::ApplicationCommandTarget* getNextCommandTarget() override;
 

--- a/src/gui/windows/MainWindow.cpp
+++ b/src/gui/windows/MainWindow.cpp
@@ -16,14 +16,17 @@ namespace gui
  *
  * @param[in]   name    Window name
  */
-MainWindow::MainWindow(const juce::String& name,
-                       std::shared_ptr<ConfigurationValueTree> sharedConfigValueTree,
-                       std::shared_ptr<CommandManager> sharedCommandManager)
+MainWindow::MainWindow(
+    const juce::String& name,
+    std::shared_ptr<ConfigurationValueTree> sharedConfigValueTree,
+    std::shared_ptr<CommandManager> sharedCommandManager)
     : juce::DocumentWindow(
         name,
-        juce::Desktop::getInstance().getDefaultLookAndFeel().findColour(juce::ResizableWindow::backgroundColourId),
+        juce::Desktop::getInstance().getDefaultLookAndFeel().findColour(
+            juce::ResizableWindow::backgroundColourId),
         DocumentWindow::allButtons),
-      menuBar(sharedCommandManager), mainComponent(sharedConfigValueTree), commandManager(sharedCommandManager)
+      menuBar(sharedCommandManager), mainComponent(sharedConfigValueTree),
+      commandManager(sharedCommandManager)
 {
     setUsingNativeTitleBar(true);
     setResizeLimits(minWidth, minHeight, INT_MAX, INT_MAX);
@@ -72,32 +75,49 @@ void MainWindow::getAllCommands(juce::Array<juce::CommandID>& commands)
 /**
  * @brief Implements juce::ApplicationCommandTarget::getCommandInfo()
  */
-void MainWindow::getCommandInfo(juce::CommandID commandID, juce::ApplicationCommandInfo& result)
+void MainWindow::getCommandInfo(juce::CommandID commandID,
+                                juce::ApplicationCommandInfo& result)
 {
     switch (commandID)
     {
     case CommandManager::CloseWindow:
     {
-        result.setInfo("Close", "Closes the window", CommandManager::CommandCategories::GUI, 0);
-        result.defaultKeypresses.add(juce::KeyPress('w', juce::ModifierKeys::commandModifier, 0));
+        result.setInfo("Close",
+                       "Closes the window",
+                       CommandManager::CommandCategories::GUI,
+                       0);
+        result.defaultKeypresses.add(
+            juce::KeyPress('w', juce::ModifierKeys::commandModifier, 0));
         break;
     }
 
     case CommandManager::MinimiseWindow:
     {
-        result.setInfo("Minimise", "Minimises the window", CommandManager::CommandCategories::GUI, 0);
-        result.defaultKeypresses.add(juce::KeyPress('m', juce::ModifierKeys::commandModifier, 0));
+        result.setInfo("Minimise",
+                       "Minimises the window",
+                       CommandManager::CommandCategories::GUI,
+                       0);
+        result.defaultKeypresses.add(
+            juce::KeyPress('m', juce::ModifierKeys::commandModifier, 0));
         break;
     }
 
     case CommandManager::ToggleFullScreen:
     {
-        const juce::String shortName = !isFullScreen() ? "Enter Full Screen" : "Exit Full Screen";
-        const juce::String longName = !isFullScreen() ? "Enters full screen" : "Exits full screen";
+        const juce::String shortName
+            = !isFullScreen() ? "Enter Full Screen" : "Exit Full Screen";
+        const juce::String longName
+            = !isFullScreen() ? "Enters full screen" : "Exits full screen";
 
-        result.setInfo(shortName, longName, CommandManager::CommandCategories::GUI, 0);
+        result.setInfo(shortName,
+                       longName,
+                       CommandManager::CommandCategories::GUI,
+                       0);
         result.defaultKeypresses.add(
-            juce::KeyPress('f', juce::ModifierKeys::commandModifier | juce::ModifierKeys::ctrlModifier, 0));
+            juce::KeyPress('f',
+                           juce::ModifierKeys::commandModifier
+                               | juce::ModifierKeys::ctrlModifier,
+                           0));
         break;
     }
 

--- a/src/gui/windows/MainWindow.h
+++ b/src/gui/windows/MainWindow.h
@@ -19,7 +19,8 @@ namespace gui
 /**
  * @brief Main GUI window
  */
-class MainWindow : public juce::DocumentWindow, public juce::ApplicationCommandTarget
+class MainWindow : public juce::DocumentWindow,
+                   public juce::ApplicationCommandTarget
 {
 public:
 
@@ -32,7 +33,8 @@ public:
 
     // command handling
     void getAllCommands(juce::Array<juce::CommandID>& commands) override;
-    void getCommandInfo(juce::CommandID commandID, juce::ApplicationCommandInfo& result) override;
+    void getCommandInfo(juce::CommandID commandID,
+                        juce::ApplicationCommandInfo& result) override;
     bool perform(const InvocationInfo& info) override;
     juce::ApplicationCommandTarget* getNextCommandTarget() override;
 

--- a/src/utility/linspace.h
+++ b/src/utility/linspace.h
@@ -11,12 +11,14 @@
 /**
  * @brief       Creates a vector of linearly spaced values
  *
- * @note        When used with integers, rounding may result in duplicate points or slightly non-linear spacing,
- *              depending on the number and range of values. Choose parameters carefully for sensible results.
+ * @note        When used with integers, rounding may result in duplicate points
+ * or slightly non-linear spacing, depending on the number and range of values.
+ * Choose parameters carefully for sensible results.
  *
  * @see         Heavily based on various gists on GitHub, see:
  *              - https://gist.github.com/lorenzoriano/5414671
- *              - https://gist.github.com/parequena/689dbfe2a4fca9c8203c76ab715bf75c
+ *              -
+ * https://gist.github.com/parequena/689dbfe2a4fca9c8203c76ab715bf75c
  *
  * @param[in]   start   First value in the space
  * @param[in]   end     Last value in the space


### PR DESCRIPTION
## Description

- Updates `clang-format` config to reduce line limit to 80 cols.
- Applies new formatting.
- General cleanup of in-source documentation format.

## Checklist

- [x] Code linted with `trunk check`
- [x] Code formatted with `trunk fmt`
- [x] Changes do not generate any new compiler warnings
- [x] Commit messages follow the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
