### PR TITLE
feat(gui): add config load/save to menu bar

### DIFF
--- a/src/CommandManager.h
+++ b/src/CommandManager.h
@@ -30,11 +30,16 @@ public:
         CloseWindow = 0x100030,
         MinimiseWindow = 0x100031,
         ToggleFullScreen = 0x100032,
+
+        // config actions
+        ImportConfig = 0x100040,
+        ExportConfig = 0x100041
     };
 
     struct CommandCategories
     {
-        inline static const char* General = "General";
-        inline static const char* GUI = "GUI";
+        static constexpr const char* General = "General";
+        static constexpr const char* GUI = "GUI";
+        static constexpr const char* Config = "Configuration";
     };
 };

--- a/src/CommandManager.h
+++ b/src/CommandManager.h
@@ -32,8 +32,8 @@ public:
         ToggleFullScreen = 0x100032,
 
         // config actions
-        ImportConfig = 0x100040,
-        ExportConfig = 0x100041
+        OpenFile = 0x100040,
+        SaveFile = 0x100041
     };
 
     struct CommandCategories

--- a/src/gui/menubar/MenuBar.cpp
+++ b/src/gui/menubar/MenuBar.cpp
@@ -67,6 +67,16 @@ void MenuBar::setupAppleMenu()
 #endif
 
 /**
+ * @brief   Creates the 'File' menu
+ */
+juce::PopupMenu MenuBar::createFileMenu()
+{
+    juce::PopupMenu menu;
+
+    return menu;
+}
+
+/**
  * @brief Creates the 'Window' menu
  */
 juce::PopupMenu MenuBar::createWindowMenu()
@@ -130,6 +140,9 @@ juce::PopupMenu MenuBar::getMenuForIndex(int topLevelMenuIndex,
 
     switch (topLevelMenuIndex)
     {
+    case MenuIndex::File:
+        return createFileMenu();
+
     case MenuIndex::Window:
         return createWindowMenu();
 
@@ -230,9 +243,13 @@ juce::ApplicationCommandTarget* MenuBar::getNextCommandTarget()
 //==============================================================================
 
 /**
- * @brief Map between menu indexes and identifying strings
+ * @brief   Map between menu indexes and identifying strings
+ *
+ * @note    This is done as a map and not an array to allow the menus to be
+ *          re-ordered without having to re-order the array.
  */
 const std::map<MenuBar::MenuIndex, juce::String> MenuBar::menuNameMap = {
+    {MenuBar::MenuIndex::File, "File"},
     {MenuBar::MenuIndex::View, "View"},
     {MenuBar::MenuIndex::Window, "Window"},
 };

--- a/src/gui/menubar/MenuBar.cpp
+++ b/src/gui/menubar/MenuBar.cpp
@@ -74,8 +74,8 @@ juce::PopupMenu MenuBar::createFileMenu()
     juce::PopupMenu menu;
 
     std::initializer_list<CommandManager::CommandIDs> commands = {
-        CommandManager::ImportConfig,
-        CommandManager::ExportConfig,
+        CommandManager::OpenFile,
+        CommandManager::SaveFile,
     };
 
     for (const auto& cmd : commands)

--- a/src/gui/menubar/MenuBar.cpp
+++ b/src/gui/menubar/MenuBar.cpp
@@ -73,6 +73,16 @@ juce::PopupMenu MenuBar::createFileMenu()
 {
     juce::PopupMenu menu;
 
+    std::initializer_list<CommandManager::CommandIDs> commands = {
+        CommandManager::ImportConfig,
+        CommandManager::ExportConfig,
+    };
+
+    for (const auto& cmd : commands)
+    {
+        menu.addCommandItem(commandManager.get(), cmd);
+    }
+
     return menu;
 }
 

--- a/src/gui/menubar/MenuBar.h
+++ b/src/gui/menubar/MenuBar.h
@@ -44,10 +44,11 @@ private:
 
     //==========================================================================
     void createMainMenu();
+    juce::PopupMenu createFileMenu();
     juce::PopupMenu createWindowMenu();
     juce::PopupMenu createViewMenu();
 
-#if JUCE_MAC
+#if (JUCE_MAC)
     void setupAppleMenu();
 #endif
 
@@ -58,8 +59,9 @@ private:
 
     typedef enum
     {
-        View = 0,
-        Window = 1,
+        File = 0,
+        View = 1,
+        Window = 2
     } MenuIndex;
 
     static const std::map<MenuIndex, juce::String> menuNameMap;

--- a/src/gui/windows/MainWindow.h
+++ b/src/gui/windows/MainWindow.h
@@ -43,9 +43,15 @@ public:
 private:
 
     //==========================================================================
+    void loadConfig();
+    void saveConfig();
+
+    //==========================================================================
     MenuBar menuBar;
     MainComponent mainComponent;
     std::shared_ptr<CommandManager> commandManager;
+    std::shared_ptr<ConfigurationValueTree> configValueTree;
+    std::unique_ptr<juce::FileChooser> fileChooser;
 
     //==========================================================================
     static const int minWidth = 500;


### PR DESCRIPTION
## Description

- Re-implements the config load/save functionality which used to be buttons in the main component.
- Fixes an issue where the torque map graph didn't sync with the config value tree when the deadzone was moved.

Closes #108 

## Checklist

- [x] Code linted with `trunk check`
- [x] Code formatted with `trunk fmt`
- [x] Changes do not generate any new compiler warnings
- [x] Commit messages follow the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
