### PR TITLE
feat(config): outline for config parameter classes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ target_include_directories(${TARGET_NAME}
 )
 
 add_subdirectory(src/gui)
+add_subdirectory(src/config)
 
 # binary data
 juce_add_binary_data(${TARGET_NAME}Data
@@ -78,8 +79,6 @@ execute_process(
     OUTPUT_VARIABLE GIT_COMMIT_HASH
     OUTPUT_STRIP_TRAILING_WHITESPACE
 )
-
-
 
 # compilation
 target_compile_definitions(${TARGET_NAME}
@@ -108,4 +107,6 @@ target_link_libraries(${TARGET_NAME}
 )
 
 # symlink compile commands to repo root
+# this needs to be in the repo root for trunk to work
+# TODO: this won't work on windows!
 execute_process(COMMAND ln -sf ${CMAKE_SOURCE_DIR}/build/compile_commands.json ${CMAKE_SOURCE_DIR}/compile_commands.json)

--- a/src/config/CMakeLists.txt
+++ b/src/config/CMakeLists.txt
@@ -11,4 +11,5 @@
 target_sources(${TARGET_NAME}
     PRIVATE 
         ConfigParameter.cpp
+        ConfigParameterGroup.cpp
 )

--- a/src/config/CMakeLists.txt
+++ b/src/config/CMakeLists.txt
@@ -1,0 +1,14 @@
+###############################################################################
+#                   :
+#   File            :   CMakeLists.txt
+#                   :
+#   Author(s)       :   Tim Brewis (@t-bre)
+#                   :
+#   Description     :   CMakeLists for configuration model and parameters
+#                   :
+###############################################################################
+
+target_sources(${TARGET_NAME}
+    PRIVATE 
+        ConfigParameter.cpp
+)

--- a/src/config/ConfigParameter.cpp
+++ b/src/config/ConfigParameter.cpp
@@ -1,0 +1,88 @@
+/******************************************************************************
+ * @file    ConfigParameter.cpp
+ * @author  Tim Brewis (@t-bre)
+ *****************************************************************************/
+
+#include "ConfigParameter.h"
+
+//==============================================================================
+
+/**
+ * @brief       Create a new parameter with the specified identifier
+ *
+ * @param[in]   parameterID     Identifier
+ * @param[in]   parameterName   Display name
+ */
+ConfigParameter::ConfigParameter(const juce::String& parameterID,
+                                 const juce::String& parameterName)
+    : identifier(parameterID), name(parameterName)
+{
+}
+
+//==============================================================================
+
+/**
+ * @brief       Sets the value of the parameter
+ *
+ * @details     This defaults to just setting the variant
+ *
+ * @param[in]   newValue    New value to set
+ */
+void ConfigParameter::setValue(const juce::var& newValue)
+{
+    setVar(newValue);
+}
+
+/**
+ * @brief   Returns the value of the parameter
+ */
+const juce::var ConfigParameter::getValue() const
+{
+    return value.getValue();
+}
+
+/**
+ * @brief   Returns true if the value is valid
+ *
+ * @note    See comments on validate()
+ */
+bool ConfigParameter::isValid() const
+{
+    return validate();
+}
+
+//==============================================================================
+
+/**
+ * @brief   Validates the value of the variant
+ *
+ * @details This class assumes any value is valid, base classes can override
+ *          this to perform their own validation logic
+ *
+ * @return true     The value is valid
+ * @return false    The value is invalid
+ */
+bool ConfigParameter::validate() const
+{
+    return true;
+}
+
+//==============================================================================
+
+/**
+ * @brief       Sets the value of the internal variant
+ *
+ * @param[in]   newValue    New value to assign
+ */
+void ConfigParameter::setVar(const juce::var& newValue)
+{
+    value = newValue;
+}
+
+/**
+ * @brief Gets the value of the internal variant
+ */
+const juce::var ConfigParameter::getVar() const
+{
+    return value.getValue();
+}

--- a/src/config/ConfigParameter.h
+++ b/src/config/ConfigParameter.h
@@ -1,0 +1,58 @@
+/******************************************************************************
+ * @file    ConfigParameter.h
+ * @author  Tim Brewis (@t-bre)
+ *****************************************************************************/
+
+#pragma once
+
+#include <JuceHeader.h>
+
+/**
+ * @brief   Variant class for storing parameters
+ *
+ * @details This is mostly a wrapper class around juce::var which provides some
+ *          extra functionality specific to our requirements
+ */
+class ConfigParameter
+{
+public:
+
+    //==========================================================================
+    ConfigParameter() = delete;
+    ConfigParameter(const juce::String& parameterID,
+                    const juce::String& parameterName);
+    virtual ~ConfigParameter() = default;
+
+    //==========================================================================
+    virtual void setValue(const juce::var& newValue);
+    virtual const juce::var getValue() const;
+
+    //==========================================================================
+    bool isValid() const;
+
+protected:
+
+    //==========================================================================
+    void setVar(const juce::var& newValue);
+    const juce::var getVar() const;
+    virtual bool validate() const;
+
+private:
+
+    //==========================================================================
+
+    /**
+     * @brief   Identifier
+     */
+    juce::String identifier;
+
+    /**
+     * @brief   Display name (e.g. for use in GUI)
+     */
+    juce::String name;
+
+    /**
+     * @brief   Variant for storing value
+     */
+    juce::Value value;
+};

--- a/src/config/ConfigParameterGroup.cpp
+++ b/src/config/ConfigParameterGroup.cpp
@@ -1,0 +1,98 @@
+/******************************************************************************
+ * @file    ConfigParameterGroup.cpp
+ * @author  Tim Brewis (@t-bre)
+ *****************************************************************************/
+
+#include "ConfigParameterGroup.h"
+
+//==============================================================================
+
+/**
+ * @brief       Default constructor
+ *
+ * @param[in]   groupID     Identifier for group
+ * @param[in]   groupName   Name of group
+ */
+ConfigParameterGroup::ConfigParameterGroup(const juce::String& groupID,
+                                           const juce::String& groupName)
+    : identifier(groupID), name(groupName)
+{
+}
+
+//==============================================================================
+
+/**
+ * @brief       Creates a new node from a parameter
+ *
+ * @param[in]   parameter       Parameter associated with node
+ * @param[in]   parentGroup     Parent group of node
+ */
+ConfigParameterGroup::ConfigParameterNode::ConfigParameterNode(
+    std::unique_ptr<ConfigParameter> parameter,
+    ConfigParameterGroup* parentGroup)
+    : param(std::move(parameter)), parent(parentGroup)
+{
+}
+
+/**
+ * @brief       Creates a new node from a parameter group
+ *
+ * @param[in]   grp             Group
+ * @param[in]   parentGroup     Parent group of group
+ */
+ConfigParameterGroup::ConfigParameterNode::ConfigParameterNode(
+    std::unique_ptr<ConfigParameterGroup> grp,
+    ConfigParameterGroup* parentGroup)
+    : group(std::move(grp)), parent(parentGroup)
+{
+}
+
+/**
+ * @brief   Returns the parent group or nullptr if top level group
+ */
+ConfigParameterGroup*
+ConfigParameterGroup::ConfigParameterNode::getParent() const
+{
+    return parent;
+}
+
+/**
+ * @brief   Returns a pointer to the parameter if this node is a group,
+ *          and nullptr otherwise
+ */
+ConfigParameterGroup*
+ConfigParameterGroup::ConfigParameterNode::getGroup() const
+{
+    return group.get();
+}
+
+/**
+ * @brief   Returns a pointer to the parameter if this node is a parameter,
+ *          and nullptr otherwise
+ */
+ConfigParameter* ConfigParameterGroup::ConfigParameterNode::getParameter() const
+{
+    return param.get();
+}
+
+//==============================================================================
+
+/**
+ * @brief       Adds a subgroup to this group
+ *
+ * @param[in]   group   Subgroup to add
+ */
+void ConfigParameterGroup::append(std::unique_ptr<ConfigParameterGroup> group)
+{
+    children.add(new ConfigParameterNode(std::move(group), this));
+}
+
+/**
+ * @brief       Adds a parameter to this group
+ *
+ * @param[in]   parameter   parameter to add
+ */
+void ConfigParameterGroup::append(std::unique_ptr<ConfigParameter> parameter)
+{
+    children.add(new ConfigParameterNode(std::move(parameter), this));
+}

--- a/src/config/ConfigParameterGroup.h
+++ b/src/config/ConfigParameterGroup.h
@@ -1,0 +1,78 @@
+/******************************************************************************
+ * @file    ConfigParameterGroup.h
+ * @author  Tim Brewis (@t-bre)
+ *****************************************************************************/
+
+#pragma once
+
+#include "ConfigParameter.h"
+#include <JuceHeader.h>
+
+/**
+ * @brief   Group of config parameters
+ *
+ * @note    Based on juce::AudioProcessorParameterGroup
+ */
+class ConfigParameterGroup
+{
+public:
+
+    //==========================================================================
+    ConfigParameterGroup(const juce::String& groupID,
+                         const juce::String& groupName);
+
+    //==========================================================================
+
+    /**
+     * @brief   Contains either a ConfigParameter or a ConfigParameterGroup
+     *
+     * @note    Pretty much an exact clone of juce::AudioProcessorParameterNode
+     */
+    class ConfigParameterNode
+    {
+    public:
+
+        ConfigParameterNode() = delete;
+        ~ConfigParameterNode() = default;
+
+        ConfigParameterGroup* getParent() const;
+        ConfigParameter* getParameter() const;
+        ConfigParameterGroup* getGroup() const;
+
+    private:
+
+        ConfigParameterNode(std::unique_ptr<ConfigParameter> parameter,
+                            ConfigParameterGroup* parentGroup);
+        ConfigParameterNode(std::unique_ptr<ConfigParameterGroup> grp,
+                            ConfigParameterGroup* parentGroup);
+
+        std::unique_ptr<ConfigParameter> param;
+        std::unique_ptr<ConfigParameterGroup> group;
+        ConfigParameterGroup* parent = nullptr;
+
+        friend class ConfigParameterGroup;
+        JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(ConfigParameterNode)
+    };
+
+    //==========================================================================
+
+    template <typename ChildType>
+    void addChild(std::unique_ptr<ChildType> child)
+    {
+        append(std::move(child));
+    }
+
+private:
+
+    //==========================================================================
+    void append(std::unique_ptr<ConfigParameter>);
+    void append(std::unique_ptr<ConfigParameterGroup>);
+
+    //==========================================================================
+    juce::String identifier;
+    juce::String name;
+    juce::OwnedArray<ConfigParameterNode> children;
+
+    //==========================================================================
+    static constexpr const char* subgroupSeparator = ".";
+};

--- a/src/config/ConfigParameterRanged.h
+++ b/src/config/ConfigParameterRanged.h
@@ -1,0 +1,82 @@
+/******************************************************************************
+ * @file    ConfigParameterRanged.h
+ * @author  Tim Brewis (@t-bre)
+ *****************************************************************************/
+
+#pragma once
+
+#include "../utility/clip.h"
+#include "ConfigParameter.h"
+
+/**
+ * @brief   Ranged configuration parameter
+ */
+template <typename ValueType>
+class ConfigParameterRanged : public ConfigParameter
+{
+public:
+
+    //==========================================================================
+    ConfigParameterRanged() = delete;
+
+    /**
+     * @brief       Create a new ranged parameter
+     *
+     * @param[in]   parameterID     Parameter identifier
+     * @param[in]   parameterName   Parameter name
+     * @param[in]   minValue        Minimum value
+     * @param[in]   maxValue        Maximum value
+     * @param[in]   defaultValue    Default/initial value
+     * @param[in]   shouldClip      Sets whether the value should be clipped to
+     *                              the specified range when setting it
+     */
+    ConfigParameterRanged(const juce::String& parameterID,
+                          const juce::String& parameterName,
+                          ValueType minValue,
+                          ValueType maxValue,
+                          ValueType defaultValue,
+                          bool shouldClip)
+        : ConfigParameter(parameterID, parameterName), min(minValue),
+          max(maxValue), applyClipping(shouldClip)
+    {
+        // TODO: the length of the parameter list is a bit silly here
+        setValue(defaultValue);
+    }
+
+    /**
+     * @brief   Destructor
+     */
+    ~ConfigParameterRanged() override = default;
+
+    //==========================================================================
+
+    /**
+     * @brief       Sets the value of the parameter, applying clipping to range
+     *              if enabled
+     *
+     * @param[in]   newValue    New value to set
+     */
+    void setValue(const juce::var& newValue) override
+    {
+        auto unclipped = static_cast<ValueType>(newValue);
+        setVar(applyClipping ? utility::clip(unclipped, min, max) : unclipped);
+    }
+
+private:
+
+    //==========================================================================
+
+    /**
+     * @brief   Implements ConfigParameter::validate()
+     */
+    bool validate() const override
+    {
+        auto value = static_cast<ValueType>(getVar());
+        return (min <= value) && (value <= max);
+    }
+
+    //==========================================================================
+    ValueType min;
+    ValueType max;
+    bool applyClipping;
+};


### PR DESCRIPTION
## Description

- Initial attempt at some classes for defining configuration parameters.
- Based on a mix of `juce::Value` and `juce::AudioProcessorParameter`.
- Needs some more work once the container for the data model is better defined.

## Checklist

- [x] Code linted with `trunk check`
- [x] Code formatted with `trunk fmt`
- [x] Changes do not generate any new compiler warnings
- [x] Commit messages follow the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
