### PR TITLE
build(windows): add global _USE_MATH_DEFINE to root CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,11 +17,6 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 project(VCU-GUI VERSION 1.1.0)
 set(TARGET_NAME ${PROJECT_NAME})
 
-# Must define '_USE_MATH_DEFINES' before #include <cmath>.
-# See https://learn.microsoft.com/en-us/cpp/c-runtime-library/math-constants?view=msvc-170
-# We define it globally here.
-add_compile_definitions(_USE_MATH_DEFINES=1)
-
 # OS / architecture specific
 if(APPLE)
     if(CMAKE_BUILD_TYPE MATCHES Debug)
@@ -84,11 +79,13 @@ execute_process(
     OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
-
-
 # compilation
 target_compile_definitions(${TARGET_NAME}
     PRIVATE
+    # Must define '_USE_MATH_DEFINES' before #include <cmath>.
+    # See https://learn.microsoft.com/en-us/cpp/c-runtime-library/math-constants?view=msvc-170
+    # We define it globally here.
+        _USE_MATH_DEFINES=1
         JUCE_WEB_BROWSER=0
         JUCE_USE_CURL=0
         JUCE_APPLICATION_NAME_STRING="$<TARGET_PROPERTY:${PROJECT_NAME},JUCE_PRODUCT_NAME>"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,11 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 project(VCU-GUI VERSION 1.1.0)
 set(TARGET_NAME ${PROJECT_NAME})
 
+# Must define '_USE_MATH_DEFINES' before #include <cmath>.
+# See https://learn.microsoft.com/en-us/cpp/c-runtime-library/math-constants?view=msvc-170
+# We define it globally here.
+add_compile_definitions(_USE_MATH_DEFINES=1)
+
 # OS / architecture specific
 if(APPLE)
     if(CMAKE_BUILD_TYPE MATCHES Debug)

--- a/src/Interpolator.h
+++ b/src/Interpolator.h
@@ -15,8 +15,7 @@
     #pragma GCC diagnostic ignored "-Wmissing-prototypes"
     #pragma GCC diagnostic ignored "-Wc++98-compat-extra-semi"
 #elif (JUCE_WINDOWS)
-    // TODO: add MSVC equivalent pragmas
-    #define M_PI juce::MathConstants<float>::pi
+// TODO: add MSVC equivalent pragmas
 #endif
 
 #ifndef NDEBUG


### PR DESCRIPTION
## Description

- Added global define in CMakeList to remove build error for M_PI in spline.h

Better fix for #96 

## Checklist

- [x] Code linted with `trunk check`
- [x] Code formatted with `trunk fmt`
- [x] Changes do not generate any new compiler warnings
- [ ] Commit messages follow the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
