### PR TITLE
refactor(utils): move Interpolator into utility folder

### DIFF
--- a/src/ConfigurationValueTree.cpp
+++ b/src/ConfigurationValueTree.cpp
@@ -6,7 +6,7 @@
 
 #include "ConfigurationValueTree.h"
 
-#include "Interpolator.h"
+#include "utility/Interpolator.h"
 
 using utility::InterpolatorFactory;
 using utility::LinearInterpolator;

--- a/src/gui/components/MainComponent.cpp
+++ b/src/gui/components/MainComponent.cpp
@@ -7,8 +7,6 @@
 
 #include "MainComponent.h"
 
-#include "../../Interpolator.h"
-
 namespace gui
 {
 

--- a/src/gui/components/config/GraphComponent.h
+++ b/src/gui/components/config/GraphComponent.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include "../../../Interpolator.h"
+#include "../../../utility/Interpolator.h"
 #include "../../../utility/PointComparator.h"
 #include "../../../utility/clip.h"
 #include "../../appearance/Colours.h"

--- a/src/utility/Interpolator.h
+++ b/src/utility/Interpolator.h
@@ -31,7 +31,7 @@
     #pragma GCC diagnostic pop
 #endif
 
-#include "utility/linspace.h"
+#include "linspace.h"
 #include <algorithm>
 #include <cmath>
 #include <memory>


### PR DESCRIPTION
## Description

- Moves `Interpolator` class into utilities folder.
- It was in the `utility` namespace, so it makes sense for it to be there.

## Checklist

- [x] Code linted with `trunk check`
- [x] Code formatted with `trunk fmt`
- [x] Changes do not generate any new compiler warnings
- [x] Commit messages follow the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
