### PR TITLE
chore(vscode): set up build/run/debug on Windows

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -41,6 +41,26 @@
       },
       "compileCommands": "${workspaceFolder}/compile_commands.json",
       "configurationProvider": "ms-vscode.cmake-tools"
+    },
+    {
+      "name": "Win32",
+      "includePath": [
+        "${workspaceFolder}/src/**",
+        "${workspaceFolder}/lib/juce/modules/**",
+        "${workspaceFolder}/build/VCU-GUI_artefacts/JuceLibraryCode/**",
+        "${workspaceFolder}/lib/juce/modules",
+        "${workspaceFolder}/lib/spline/src"
+      ],
+      "defines": [],
+      "cStandard": "c17",
+      "cppStandard": "c++17",
+      "intelliSenseMode": "windows-msvc-x86",
+      "browse": {
+        "limitSymbolsToIncludedHeaders": true,
+        "databaseFilename": ""
+      },
+      "compileCommands": "${workspaceFolder}/build/compile_commands.json",
+      "configurationProvider": "ms-vscode.cmake-tools"
     }
   ],
   "version": 4

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -49,6 +49,17 @@
         "environment": [],
         "externalConsole": false,
         "MIMode": "lldb"
+      },
+    {
+        "name": "(cppvsdbg-Windows) Launch",
+        "type": "cppvsdbg",
+        "request": "launch",
+        "program": "${workspaceFolder}/build/VCU-GUI_artefacts/Debug/VCU GUI.exe",
+        "args": [],
+        "stopAtEntry": false,
+        "cwd": "${fileDirname}",
+        "environment": [],
+        "externalConsole": false,
       }
   ]
 }


### PR DESCRIPTION
## Description

Edited launch.json file and tested debugger. Needed to install the Windows SDK separately and explicitly choose Debugging tools for windows. TODO: update the Dev Setup.md with this information.
Update the docs folder for windows set up.
Edited the c_cpp_properties.json file. Intellisense works but was unable to solve issue regarding compile_commands.json not found. @t-bre looked through your suggestions but as I have no experience doing this or working with MSVC I was unable to figure it out, if you do have another solution in mind let me know

Closes #115 

## Checklist

- [x] N/A ~~Code linted with `trunk check`~~
- [x] N/A ~~Code formatted with `trunk fmt`~~
- [x] N/A ~~Changes do not generate any new compiler warnings~~
- [x] Commit messages follow the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
