### PR TITLE
fix(gui): add menu bar to main window on Linux and Windows

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -34,6 +34,10 @@ void Application::initialise(const juce::String& /*commandLine*/)
  */
 void Application::shutdown()
 {
+    // this prevents components from referencing the sufst::LookAndFeel instance
+    // after it is destroyed
+    LookAndFeel::setDefaultLookAndFeel(nullptr);
+
     mainWindow.reset();
 }
 

--- a/src/Application.h
+++ b/src/Application.h
@@ -41,9 +41,10 @@ public:
 private:
 
     //==========================================================================
+    sufst::LookAndFeel lookAndFeel;
+
     std::unique_ptr<gui::MainWindow> mainWindow;
     std::shared_ptr<CommandManager> commandManager;
 
     config::DataModel configData;
-    sufst::LookAndFeel lookAndFeel;
 };

--- a/src/gui/windows/MainWindow.cpp
+++ b/src/gui/windows/MainWindow.cpp
@@ -8,6 +8,8 @@
 
 #include <climits>
 
+#define MENU_BAR_IN_WINDOW (JUCE_WINDOWS || JUCE_LINUX)
+
 namespace gui
 {
 
@@ -38,6 +40,10 @@ MainWindow::MainWindow(const juce::String& name,
 
     setContentNonOwned(&mainComponent, true);
 
+#if (MENU_BAR_IN_WINDOW)
+    setMenuBar(&menuBar);
+#endif
+
     jassert(commandManager);
     commandManager->registerAllCommandsForTarget(this);
     addKeyListener(commandManager->getKeyMappings());
@@ -49,6 +55,10 @@ MainWindow::MainWindow(const juce::String& name,
 MainWindow::~MainWindow()
 {
     commandManager->setFirstCommandTarget(nullptr);
+
+#if (MENU_BAR_IN_WINDOW)
+    setMenuBar(nullptr);
+#endif
 }
 
 //==============================================================================


### PR DESCRIPTION
## Description

- Previously non-existent menu bar added to top of `MainWindow` on Linux and Windows platforms.
- Fixes an issue where the `sufst::LookAndFeel` instance was deleted but still referenced by some components. Weirdly, this has never happened before and only seemed to become a problem when the menu bar was added to the main window.

Closes #109 

## Checklist

- [x] Code linted with `trunk check`
- [x] Code formatted with `trunk fmt`
- [x] Changes do not generate any new compiler warnings
- [x] Commit messages follow the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
