### PR TITLE
feat(gui): add 'Help' menu to menu bar

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,7 @@ target_compile_definitions(${TARGET_NAME}
         JUCE_APPLICATION_NAME_STRING="$<TARGET_PROPERTY:${PROJECT_NAME},JUCE_PRODUCT_NAME>"
         JUCE_APPLICATION_VERSION_STRING="$<TARGET_PROPERTY:${PROJECT_NAME},JUCE_VERSION>"
         -DGIT_COMMIT_HASH=\"${GIT_COMMIT_HASH}\"
+        -DGITHUB_REPO_URL="https://github.com/sufst/vcu-gui"
 )
 
 # linking

--- a/src/CommandManager.h
+++ b/src/CommandManager.h
@@ -25,6 +25,7 @@ public:
         // menu bar
         ShowAboutWindow = 0x100020,
         ShowPreferencesWindow = 0x100021,
+        ShowGitHubRepo = 0x100022,
 
         // windows
         CloseWindow = 0x100030,

--- a/src/gui/menubar/MenuBar.cpp
+++ b/src/gui/menubar/MenuBar.cpp
@@ -118,6 +118,11 @@ juce::PopupMenu MenuBar::getMenuForIndex(int topLevelMenuIndex,
             CommandManager::ToggleFullScreen,
         });
 
+    case MenuIndex::Help:
+        return createMenuWithCommands({
+            CommandManager::ShowAboutWindow,
+        });
+
     default:
         return juce::PopupMenu();
     }
@@ -217,10 +222,10 @@ juce::ApplicationCommandTarget* MenuBar::getNextCommandTarget()
  * @note    This is done as a map and not an array to allow the menus to be
  *          re-ordered without having to re-order the array.
  */
-const std::map<MenuBar::MenuIndex, juce::String> MenuBar::menuNameMap = {
-    {MenuBar::MenuIndex::File, "File"},
-    {MenuBar::MenuIndex::View, "View"},
-    {MenuBar::MenuIndex::Window, "Window"},
-};
+const std::map<MenuBar::MenuIndex, juce::String> MenuBar::menuNameMap
+    = {{MenuBar::MenuIndex::File, "File"},
+       {MenuBar::MenuIndex::View, "View"},
+       {MenuBar::MenuIndex::Window, "Window"},
+       {MenuBar::MenuIndex::Help, "Help"}};
 
 } // namespace gui

--- a/src/gui/menubar/MenuBar.cpp
+++ b/src/gui/menubar/MenuBar.cpp
@@ -21,8 +21,6 @@ MenuBar::MenuBar(std::shared_ptr<CommandManager> sharedCommandManager)
     commandManager->registerAllCommandsForTarget(this);
     setApplicationCommandManagerToWatch(commandManager.get());
 
-    createMainMenu();
-
 #if JUCE_MAC
     setupAppleMenu();
 #endif
@@ -40,29 +38,23 @@ MenuBar::~MenuBar()
 
 //==============================================================================
 
-/**
- * @brief Creates the main menu
- */
-void MenuBar::createMainMenu()
-{
-    mainMenu.addCommandItem(commandManager.get(),
-                            CommandManager::CommandIDs::ShowAboutWindow);
-}
-
 #if JUCE_MAC
 /**
  * @brief Set ups the 'Apple' menu (macOS only)
  */
 void MenuBar::setupAppleMenu()
 {
-    juce::PopupMenu::MenuItemIterator iter(mainMenu, false);
+    appleMenu.addCommandItem(commandManager.get(),
+                             CommandManager::CommandIDs::ShowAboutWindow);
+
+    juce::PopupMenu::MenuItemIterator iter(appleMenu, false);
 
     while (iter.next())
     {
         iter.getItem().setEnabled(true);
     }
 
-    setMacMainMenu(this, &mainMenu);
+    setMacMainMenu(this, &appleMenu);
 }
 #endif
 

--- a/src/gui/menubar/MenuBar.cpp
+++ b/src/gui/menubar/MenuBar.cpp
@@ -119,9 +119,8 @@ juce::PopupMenu MenuBar::getMenuForIndex(int topLevelMenuIndex,
         });
 
     case MenuIndex::Help:
-        return createMenuWithCommands({
-            CommandManager::ShowAboutWindow,
-        });
+        return createMenuWithCommands(
+            {CommandManager::ShowAboutWindow, CommandManager::ShowGitHubRepo});
 
     default:
         return juce::PopupMenu();
@@ -151,9 +150,9 @@ void MenuBar::menuBarActivated(bool /*isActive*/)
  */
 void MenuBar::getAllCommands(juce::Array<juce::CommandID>& commands)
 {
-    std::initializer_list<juce::CommandID> targetCommands = {
-        CommandManager::CommandIDs::ShowAboutWindow,
-    };
+    std::initializer_list<juce::CommandID> targetCommands
+        = {CommandManager::CommandIDs::ShowAboutWindow,
+           CommandManager::CommandIDs::ShowGitHubRepo};
 
     commands.addArray(targetCommands);
 }
@@ -170,6 +169,15 @@ void MenuBar::getCommandInfo(juce::CommandID commandID,
     {
         result.setInfo(juce::String("About ") + ProjectInfo::projectName,
                        "Shows about window",
+                       CommandManager::CommandCategories::GUI,
+                       0);
+        break;
+    }
+
+    case CommandManager::ShowGitHubRepo:
+    {
+        result.setInfo("View project on GitHub...",
+                       "Opens GitHub repo for project",
                        CommandManager::CommandCategories::GUI,
                        0);
         break;
@@ -196,6 +204,13 @@ bool MenuBar::perform(const InvocationInfo& info)
             aboutWindow->onCloseButtonPressed
                 = [this]() { aboutWindow.reset(); };
         }
+        break;
+    }
+
+    case CommandManager::ShowGitHubRepo:
+    {
+        juce::URL url(GITHUB_REPO_URL);
+        url.launchInDefaultBrowser();
         break;
     }
 

--- a/src/gui/menubar/MenuBar.h
+++ b/src/gui/menubar/MenuBar.h
@@ -43,7 +43,6 @@ public:
 private:
 
     //==========================================================================
-    void createMainMenu();
     juce::PopupMenu createMenuWithCommands(
         std::initializer_list<CommandManager::CommandIDs> commands);
 
@@ -52,7 +51,10 @@ private:
 #endif
 
     //==========================================================================
-    juce::PopupMenu mainMenu;
+#if (JUCE_MAC)
+    juce::PopupMenu appleMenu;
+#endif
+
     std::shared_ptr<CommandManager> commandManager;
     std::unique_ptr<AboutWindow> aboutWindow;
 

--- a/src/gui/menubar/MenuBar.h
+++ b/src/gui/menubar/MenuBar.h
@@ -62,7 +62,8 @@ private:
     {
         File = 0,
         View = 1,
-        Window = 2
+        Window = 2,
+        Help = 3
     } MenuIndex;
 
     static const std::map<MenuIndex, juce::String> menuNameMap;


### PR DESCRIPTION
## Description

- Adds a 'Help' menu to the menu bar.
- This provides access to the 'About' window on Windows and Linux.
- On macOS, the 'About' window is intentionally accessible both through the help menu and the "Apple menu." 
- Also includes a link to this GitHub repo in the help menu.

Fixes #140 

## Checklist

- [x] Code linted with `trunk check`
- [x] Code formatted with `trunk fmt`
- [x] Changes do not generate any new compiler warnings
- [x] Commit messages follow the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)

## Additional Information

Looks like this on macOS:

<img width="668" alt="Screenshot 2022-11-06 at 13 45 47" src="https://user-images.githubusercontent.com/31595761/200174428-61f1cb1d-99bc-4986-8c51-995919b476d7.png">

