### PR TITLE
build(windows): fix C4244 int to float conversion warning

### DIFF
--- a/src/gui/appearance/LookAndFeel.cpp
+++ b/src/gui/appearance/LookAndFeel.cpp
@@ -48,8 +48,8 @@ const juce::Typeface::Ptr LookAndFeel::getKarlaTypeface()
 int LookAndFeel::getTabButtonBestWidth(juce::TabBarButton& button,
                                        int /*tabDepth*/)
 {
-    float totalWidth = button.getTabbedButtonBar().getWidth();
-    float numTabs = button.getTabbedButtonBar().getNumTabs();
+    auto totalWidth = static_cast<float>(button.getTabbedButtonBar().getWidth());
+    auto numTabs = static_cast<float>(button.getTabbedButtonBar().getNumTabs());
     return static_cast<int>(totalWidth / numTabs);
 }
 

--- a/src/gui/appearance/LookAndFeel.cpp
+++ b/src/gui/appearance/LookAndFeel.cpp
@@ -48,7 +48,8 @@ const juce::Typeface::Ptr LookAndFeel::getKarlaTypeface()
 int LookAndFeel::getTabButtonBestWidth(juce::TabBarButton& button,
                                        int /*tabDepth*/)
 {
-    auto totalWidth = static_cast<float>(button.getTabbedButtonBar().getWidth());
+    auto totalWidth
+        = static_cast<float>(button.getTabbedButtonBar().getWidth());
     auto numTabs = static_cast<float>(button.getTabbedButtonBar().getNumTabs());
     return static_cast<int>(totalWidth / numTabs);
 }

--- a/src/gui/components/config/GraphComponent.h
+++ b/src/gui/components/config/GraphComponent.h
@@ -300,13 +300,13 @@ void GraphComponent<ValueType>::paintTicks(juce::Graphics& g) const
             {
                 int x = i * dirMult * tickSpacingX;
                 auto point = transformPointForPaint({x, 0});
-                g.drawVerticalLine(point.getX(), 0, getHeight());
+                g.drawVerticalLine(point.getX(), 0.f, static_cast<float>(getHeight()));
             }
             else
             {
                 int y = i * dirMult * tickSpacingY;
                 auto point = transformPointForPaint({0, y});
-                g.drawHorizontalLine(point.getY(), 0, getWidth());
+                g.drawHorizontalLine(point.getY(), 0.f, static_cast<float>(getWidth()));
             }
         }
     }
@@ -316,8 +316,8 @@ void GraphComponent<ValueType>::paintTicks(juce::Graphics& g) const
     PointType topCentre = transformPointForPaint({0, getMaxY()});
 
     g.setColour(borderColour);
-    g.drawVerticalLine(topCentre.getX(), 0, getHeight());
-    g.drawHorizontalLine(centreLeft.getY(), 0, getWidth());
+    g.drawVerticalLine(topCentre.getX(), 0.f, static_cast<float>(getHeight()));
+    g.drawHorizontalLine(centreLeft.getY(), 0.f, static_cast<float>(getWidth()));
 }
 
 /**

--- a/src/gui/components/config/GraphComponent.h
+++ b/src/gui/components/config/GraphComponent.h
@@ -300,13 +300,17 @@ void GraphComponent<ValueType>::paintTicks(juce::Graphics& g) const
             {
                 int x = i * dirMult * tickSpacingX;
                 auto point = transformPointForPaint({x, 0});
-                g.drawVerticalLine(point.getX(), 0.f, static_cast<float>(getHeight()));
+                g.drawVerticalLine(point.getX(),
+                                   0.f,
+                                   static_cast<float>(getHeight()));
             }
             else
             {
                 int y = i * dirMult * tickSpacingY;
                 auto point = transformPointForPaint({0, y});
-                g.drawHorizontalLine(point.getY(), 0.f, static_cast<float>(getWidth()));
+                g.drawHorizontalLine(point.getY(),
+                                     0.f,
+                                     static_cast<float>(getWidth()));
             }
         }
     }
@@ -317,7 +321,9 @@ void GraphComponent<ValueType>::paintTicks(juce::Graphics& g) const
 
     g.setColour(borderColour);
     g.drawVerticalLine(topCentre.getX(), 0.f, static_cast<float>(getHeight()));
-    g.drawHorizontalLine(centreLeft.getY(), 0.f, static_cast<float>(getWidth()));
+    g.drawHorizontalLine(centreLeft.getY(),
+                         0.f,
+                         static_cast<float>(getWidth()));
 }
 
 /**

--- a/src/gui/windows/AboutWindow.cpp
+++ b/src/gui/windows/AboutWindow.cpp
@@ -149,17 +149,17 @@ void AboutWindow::AboutComponent::setupLabels()
     const std::initializer_list<Initialiser> initList
         = {{&appNameLabel,
             juce::String(ProjectInfo::projectName),
-            50,
+            50.f,
             juce::Justification::bottomLeft,
             juce::Colour(225, 225, 225)},
            {&versionLabel,
             juce::String("Version ") + ProjectInfo::versionString,
-            18,
+            18.f,
             juce::Justification::topLeft,
             juce::Colour(180, 180, 180)},
            {&commitHashLabel,
             juce::String(GIT_COMMIT_HASH),
-            10,
+            10.f,
             juce::Justification::centredLeft,
             juce::Colour(120, 120, 120)}};
 


### PR DESCRIPTION
## Description

- Fixed C4244 warning through CMake target_compile_options command

Closes #145 

## Checklist

- [x] Code linted with `trunk check`
- [x] Code formatted with `trunk fmt`
- [x] Changes do not generate any new compiler warnings
- [x] Commit messages follow the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
