### PR TITLE
fix(gui): commit hash not shown in 'About' window on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,22 +94,9 @@ target_compile_definitions(${TARGET_NAME}
         JUCE_USE_CURL=0
         JUCE_APPLICATION_NAME_STRING="$<TARGET_PROPERTY:${PROJECT_NAME},JUCE_PRODUCT_NAME>"
         JUCE_APPLICATION_VERSION_STRING="$<TARGET_PROPERTY:${PROJECT_NAME},JUCE_VERSION>"
+        GIT_COMMIT_HASH=\"${GIT_COMMIT_HASH}\"
+        GITHUB_REPO_URL="https://github.com/sufst/vcu-gui"
 )
-
-if(MSVC) 
-    target_compile_definitions(${TARGET_NAME}
-        PRIVATE
-              GIT_COMMIT_HASH=\"${GIT_COMMIT_HASH}\"
-             -DGITHUB_REPO_URL="https://github.com/sufst/vcu-gui"
-    )
-
-else()
-   target_compile_definitions(${TARGET_NAME}
-   PRIVATE
-        -DGIT_COMMIT_HASH=\"${GIT_COMMIT_HASH}\"
-        -DGITHUB_REPO_URL="https://github.com/sufst/vcu-gui"
-    )
-endif()
 
 # linking
 target_link_libraries(${TARGET_NAME}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,9 +94,22 @@ target_compile_definitions(${TARGET_NAME}
         JUCE_USE_CURL=0
         JUCE_APPLICATION_NAME_STRING="$<TARGET_PROPERTY:${PROJECT_NAME},JUCE_PRODUCT_NAME>"
         JUCE_APPLICATION_VERSION_STRING="$<TARGET_PROPERTY:${PROJECT_NAME},JUCE_VERSION>"
+)
+
+if(MSVC) 
+    target_compile_definitions(${TARGET_NAME}
+        PRIVATE
+              GIT_COMMIT_HASH=\"${GIT_COMMIT_HASH}\"
+             -DGITHUB_REPO_URL="https://github.com/sufst/vcu-gui"
+    )
+
+else()
+   target_compile_definitions(${TARGET_NAME}
+   PRIVATE
         -DGIT_COMMIT_HASH=\"${GIT_COMMIT_HASH}\"
         -DGITHUB_REPO_URL="https://github.com/sufst/vcu-gui"
-)
+    )
+endif()
 
 # linking
 target_link_libraries(${TARGET_NAME}


### PR DESCRIPTION
## Description

- Remove -`D flag` from `-DGIT_COMMIT_HASH=\"${GIT_COMMIT_HASH}\"` for MSVC to display hash in 'About' window on Windows

Closes #144 

## Checklist

- [x] Code linted with `trunk check`
- [x] Code formatted with `trunk fmt`
- [x] Changes do not generate any new compiler warnings
- [x] Commit messages follow the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
