### PR TITLE
feat: add esc key support for torque curve deletion

### DIFF
--- a/src/gui/components/config/GraphComponent.h
+++ b/src/gui/components/config/GraphComponent.h
@@ -603,7 +603,7 @@ bool GraphComponent<ValueType>::keyPressed(
         setDeletionState(true);
         return true;
     }
-    
+
     if (key.isKeyCode(juce::KeyPress::escapeKey))
     {
         if (pointEditState == PointEditingState::Delete)
@@ -630,7 +630,8 @@ bool GraphComponent<ValueType>::keyPressed(const juce::KeyPress& key)
 template <typename ValueType>
 void GraphComponent<ValueType>::setDeletionState(bool enabled)
 {
-    pointEditState = enabled ? PointEditingState::Delete : PointEditingState::None;
+    pointEditState
+        = enabled ? PointEditingState::Delete : PointEditingState::None;
     updateCursor();
 }
 

--- a/src/gui/components/config/GraphComponent.h
+++ b/src/gui/components/config/GraphComponent.h
@@ -598,14 +598,17 @@ bool GraphComponent<ValueType>::keyPressed(
 {
     if (key.isKeyCode(juce::KeyPress::backspaceKey))
     {
-        pointEditState = (pointEditState == PointEditingState::Delete)
-                             ? PointEditingState::None
-                             : PointEditingState::Delete;
-
+        pointEditState = PointEditingState::Delete;
         updateCursor();
         return true;
     }
-
+    else if (key.isKeyCode(juce::KeyPress::escapeKey)
+             && pointEditState == PointEditingState::Delete)
+    {
+        pointEditState = PointEditingState::None;
+        updateCursor();
+        return true;
+    }
     return false;
 }
 

--- a/src/gui/components/config/GraphComponent.h
+++ b/src/gui/components/config/GraphComponent.h
@@ -596,20 +596,29 @@ bool GraphComponent<ValueType>::keyPressed(
     const juce::KeyPress& key,
     juce::Component* /*originatingComponent*/)
 {
-    if (key.isKeyCode(juce::KeyPress::backspaceKey))
+    bool updated = false;
+
+    switch (key.keyCode)
     {
+    case juce::KeyPress::backspaceKey:
         pointEditState = PointEditingState::Delete;
-        updateCursor();
-        return true;
+        updated = true;
+        break;
+    case juce::KeyPress::escapeKey:
+        if (pointEditState == PointEditingState::Delete)
+        {
+            pointEditState = PointEditingState::None;
+        }
+        updated = true;
+
+        break;
+    default:
     }
-    else if (key.isKeyCode(juce::KeyPress::escapeKey)
-             && pointEditState == PointEditingState::Delete)
-    {
-        pointEditState = PointEditingState::None;
+
+    if (updated)
         updateCursor();
-        return true;
-    }
-    return false;
+
+    return updated;
 }
 
 /**

--- a/src/gui/components/config/GraphComponent.h
+++ b/src/gui/components/config/GraphComponent.h
@@ -65,6 +65,8 @@ protected:
                     juce::Component* originatingComponent) override;
     bool keyPressed(const juce::KeyPress& key) override;
 
+    void setDeletionState(bool enabled);
+
     //==========================================================================
     virtual int getNumPoints() const = 0;
     virtual PointType getPoint(int index) const = 0;
@@ -598,17 +600,19 @@ bool GraphComponent<ValueType>::keyPressed(
 {
     if (key.isKeyCode(juce::KeyPress::backspaceKey))
     {
-        pointEditState = PointEditingState::Delete;
-        updateCursor();
+        setDeletionState(true);
         return true;
     }
-    else if (key.isKeyCode(juce::KeyPress::escapeKey)
-             && pointEditState == PointEditingState::Delete)
+    
+    if (key.isKeyCode(juce::KeyPress::escapeKey))
     {
-        pointEditState = PointEditingState::None;
-        updateCursor();
-        return true;
+        if (pointEditState == PointEditingState::Delete)
+        {
+            setDeletionState(false);
+            return true;
+        }
     }
+
     return false;
 }
 
@@ -621,6 +625,13 @@ template <typename ValueType>
 bool GraphComponent<ValueType>::keyPressed(const juce::KeyPress& key)
 {
     return keyPressed(key, nullptr);
+}
+
+template <typename ValueType>
+void GraphComponent<ValueType>::setDeletionState(bool enabled)
+{
+    pointEditState = enabled ? PointEditingState::Delete : PointEditingState::None;
+    updateCursor();
 }
 
 //==============================================================================


### PR DESCRIPTION
## Description

- When a GraphComponent is in the point deletion mode, an escape keypress should exit deletion mode, going back to edit mode.

Closes # (issue)

## Checklist

- [ ] Code linted with `trunk check`
- [ ] Code formatted with `trunk fmt`
- [ ] Changes do not generate any new compiler warnings
- [ ] Commit messages follow the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
