### PR TITLE
Feat/coor tooltip

### DIFF
--- a/src/gui/components/config/GraphComponent.h
+++ b/src/gui/components/config/GraphComponent.h
@@ -468,7 +468,7 @@ void GraphComponent<ValueType>::mouseDown(const juce::MouseEvent& event)
     if (pointEditState == PointEditingState::None
         || pointEditState == PointEditingState::OverPoint)
     {
-        // create new
+        // create new if cursor is not pointing at a point
         if (pointIndex == -1)
         {
             const auto newPoint = transformPointToGraph(event.getPosition());

--- a/src/gui/components/config/TorqueMapComponent.cpp
+++ b/src/gui/components/config/TorqueMapComponent.cpp
@@ -333,7 +333,7 @@ bool TorqueMapComponent::shouldPreventPointEdit(
 void TorqueMapComponent::showDeadzoneTooltip()
 {
     // Make a shared pointer pointing to generalTooltip
-    auto deadzoneTooltip {generalTooltip};
+    auto deadzoneTooltip{generalTooltip};
 
     auto deadzoneX = transformPointForPaint({getDeadzonePosition(), 0}).getX();
 
@@ -352,21 +352,22 @@ void TorqueMapComponent::showDeadzoneTooltip()
 
 /**
  * @brief Shows the hovered point tooltip
-*/
+ */
 void TorqueMapComponent::showPointTooltip(int pointNo)
 {
     // Make a shared pointer pointing to generalTooltip
-    auto pointTooltip {generalTooltip};
+    auto pointTooltip{generalTooltip};
 
     // Get point and cursor position in the graph
     auto pointInGraph = getPoint(pointNo);
     auto cursorLocation = juce::Desktop::getMousePosition();
 
     // String denoting coordinates of points in the form of (x, y)
-    juce::String tipText = 
-        juce::String::toDecimalStringWithSignificantFigures(pointInGraph.x, 2) 
-        + ","
-        + juce::String::toDecimalStringWithSignificantFigures(pointInGraph.y, 3);
+    juce::String tipText
+        = juce::String::toDecimalStringWithSignificantFigures(pointInGraph.x, 2)
+          + ","
+          + juce::String::toDecimalStringWithSignificantFigures(pointInGraph.y,
+                                                                3);
 
     pointTooltip->displayTip(cursorLocation, tipText);
     pointTooltip->setVisible(true);

--- a/src/gui/components/config/TorqueMapComponent.h
+++ b/src/gui/components/config/TorqueMapComponent.h
@@ -62,10 +62,11 @@ private:
     bool mouseEventInDeadzone(const juce::MouseEvent& event) const;
     bool shouldPreventPointEdit(const juce::MouseEvent& event) const;
     void showDeadzoneTooltip();
-    void hideDeadzoneTooltip();
+    void showPointTooltip(int pointNo);
+    void hideTooltip();
 
     bool movingDeadzone = false;
-    std::unique_ptr<juce::TooltipWindow> deadzoneTooltip;
+    std::shared_ptr<juce::TooltipWindow> generalTooltip;
 
     //==========================================================================
     TorqueMap torqueMap;


### PR DESCRIPTION
## Description

- Implemented a tooltip window when hovering/moving points on the Torque Map
- The point tooltip window shares the underlying object as the deadzone tooltip window via shared pointers

Closes #53 

## Checklist

- [ ] Code linted with `trunk check`
- [ ] Code formatted with `trunk fmt`
- [ ] Changes do not generate any new compiler warnings
- [ ] Commit messages follow the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
